### PR TITLE
Re-enable filter UI and row expanding.

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -35,11 +35,11 @@ const SourcesPage = asyncComponent(() => import(
 
 const paths = {
     sources: '/',
-    sources_new: '/new',
+    sourcesNew: '/new',
 
     providers: '/providers',
-    provider_new: '/providers/new',
-    provider_detail: '/:id',
+    providerNew: '/providers/new',
+    providerDetail: '/:id',
     topology: '/:id/topology'
 };
 
@@ -77,11 +77,11 @@ export const Routes = (props) => {
     return (
         <Switch>
             <InsightsRoute exact path={paths.sources} component={SourcesPage} rootClass='providers' />
-            <InsightsRoute exact path={paths.sources_new} component={SourcesPage} rootClass='providers' />
+            <InsightsRoute exact path={paths.sourcesNew} component={SourcesPage} rootClass='providers' />
             <InsightsRoute exact path={paths.providers} component={ProviderPage} rootClass='providers' />
-            <InsightsRoute exact path={paths.provider_new} component={ProviderPage} rootClass='providers' />
+            <InsightsRoute exact path={paths.providerNew} component={ProviderPage} rootClass='providers' />
             <InsightsRoute path={paths.topology} component={TopologyPage} rootClass='provider' />
-            <InsightsRoute exact path={paths.provider_detail} component={DetailPage} rootClass='provider' />
+            <InsightsRoute exact path={paths.providerDetail} component={DetailPage} rootClass='provider' />
             { dynamicRoutes(viewDefinitions) }
 
             {/* Finally, catch all unmatched routes */}

--- a/src/components/SourceExpandedView.js
+++ b/src/components/SourceExpandedView.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
+import { Pie } from '@red-hat-insights/insights-frontend-components';
+
+import { TagView } from '@manageiq/react-ui-components/dist/tagging-pf4';
+
+class SourceExpandedView extends Component {
+    render() {
+        const { sourceId } = this.props;
+        return (
+            <Grid>
+                <GridItem sm={6} md={4} lg={4} xl={4}>
+                    <Pie withLegend identifier={`donut-${sourceId}`} values={[['Red Hat', 100], ['Google', 10]]}/>
+                </GridItem>
+                <GridItem sm={6} md={4} lg={4} xl={4}>
+                    <dl>
+                        <dt>IP Address</dt><dd>192.168.2.1</dd>
+                        <dt>Location</dt><dd>Brno</dd>
+                        <dt>Status</dt><dd>Ready for Fredie</dd>
+                        <dt>Licence</dt><dd>Apache Licence 2.0</dd>
+                    </dl>
+                </GridItem>
+                <GridItem sm={6} md={4} lg={4} xl={3}>
+                    <TagView assignedTags={
+                        [
+                            { id: 11, description: 'Environment', values: [{ id: 1, description: 'Production' }] },
+                            { id: 12, description: 'Location', values: [{ id: 2, description: 'Brno' }] },
+                            { id: 13, description: 'Server Type', values: [
+                                { id: 2, description: 'Web' },
+                                { id: 3, description: 'PostgreSQL' }] }
+                        ]
+                    } />
+                </GridItem>
+            </Grid>
+        );
+    }
+}
+
+SourceExpandedView.propTypes = {
+    sourceId: PropTypes.number.isRequired
+};
+
+export default SourceExpandedView;

--- a/src/components/SourceExpandedView.js
+++ b/src/components/SourceExpandedView.js
@@ -1,36 +1,15 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
-import { Pie } from '@red-hat-insights/insights-frontend-components';
-
-import { TagView } from '@manageiq/react-ui-components/dist/tagging-pf4';
 
 class SourceExpandedView extends Component {
     render() {
-        const { sourceId } = this.props;
         return (
             <Grid>
                 <GridItem sm={6} md={4} lg={4} xl={4}>
-                    <Pie withLegend identifier={`donut-${sourceId}`} values={[['Red Hat', 100], ['Google', 10]]}/>
-                </GridItem>
-                <GridItem sm={6} md={4} lg={4} xl={4}>
                     <dl>
-                        <dt>IP Address</dt><dd>192.168.2.1</dd>
-                        <dt>Location</dt><dd>Brno</dd>
-                        <dt>Status</dt><dd>Ready for Fredie</dd>
-                        <dt>Licence</dt><dd>Apache Licence 2.0</dd>
+                        <dt>Access Key ID (User ID)</dt><dd>TO BE ADDED</dd>
                     </dl>
-                </GridItem>
-                <GridItem sm={6} md={4} lg={4} xl={3}>
-                    <TagView assignedTags={
-                        [
-                            { id: 11, description: 'Environment', values: [{ id: 1, description: 'Production' }] },
-                            { id: 12, description: 'Location', values: [{ id: 2, description: 'Brno' }] },
-                            { id: 13, description: 'Server Type', values: [
-                                { id: 2, description: 'Web' },
-                                { id: 3, description: 'PostgreSQL' }] }
-                        ]
-                    } />
                 </GridItem>
             </Grid>
         );
@@ -38,7 +17,10 @@ class SourceExpandedView extends Component {
 }
 
 SourceExpandedView.propTypes = {
-    sourceId: PropTypes.number.isRequired
+    source: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired
+    }).isRequired
 };
 
 export default SourceExpandedView;

--- a/src/components/SourcesEmptyState.js
+++ b/src/components/SourcesEmptyState.js
@@ -11,7 +11,6 @@ import {
 } from '@patternfly/react-core';
 
 import { CubesIcon } from '@patternfly/react-icons'; // FIXME: different icon
-import { Link } from 'react-router-dom';
 
 const SourcesEmptyState = () => (
     <Card>
@@ -23,9 +22,11 @@ const SourcesEmptyState = () => (
                     <EmptyStateBody>
                         No Sources have been defined. To start define a Source.
                     </EmptyStateBody>
-                    <Link to='/new'>
-                        <Button variant="primary">Add a Source</Button>
-                    </Link>
+                    <Button
+                        component="a"
+                        href="/new"
+                        target="_blank"
+                        variant="primary">Add a Source</Button>
                 </EmptyState>
             </Bullseye>
         </CardBody>

--- a/src/components/SourcesFilter.js
+++ b/src/components/SourcesFilter.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { SimpleTableFilter } from '@red-hat-insights/insights-frontend-components';
+
+class SourcesFilter extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    onFilterButtonClick = (filterValue, column) => {
+        console.log('filter click', column.value, filterValue);
+        this.props.onFilter(column.value, filterValue);
+    }
+
+    render = () =>
+        <SimpleTableFilter
+            options={{
+                title: 'Filter By',
+                items: this.props.columns
+            }}
+            onButtonClick={this.onFilterButtonClick}
+        />
+}
+
+SourcesFilter.propTypes = {
+    columns: PropTypes.arrayOf(PropTypes.shape({
+        value: PropTypes.string,
+        title: PropTypes.string
+    })).isRequired,
+    onFilter: PropTypes.func.isRequired
+};
+
+export default SourcesFilter;

--- a/src/components/SourcesFilter.js
+++ b/src/components/SourcesFilter.js
@@ -7,18 +7,14 @@ class SourcesFilter extends Component {
         super(props);
     }
 
-    onFilterButtonClick = (filterValue, column) => {
-        console.log('filter click', column.value, filterValue);
-        this.props.onFilter(column.value, filterValue);
-    }
-
     render = () =>
         <SimpleTableFilter
             options={{
                 title: 'Filter By',
                 items: this.props.columns
             }}
-            onButtonClick={this.onFilterButtonClick}
+            onOptionSelect={this.props.onFilterSelect}
+            onButtonClick={this.props.onFilter}
         />
 }
 
@@ -27,7 +23,8 @@ SourcesFilter.propTypes = {
         value: PropTypes.string,
         title: PropTypes.string
     })).isRequired,
-    onFilter: PropTypes.func.isRequired
+    onFilter: PropTypes.func.isRequired,
+    onFilterSelect: PropTypes.func.isRequired
 };
 
 export default SourcesFilter;

--- a/src/components/SourcesSimpleView.js
+++ b/src/components/SourcesSimpleView.js
@@ -9,6 +9,7 @@ import flatten from 'lodash/flatten';
 import filter from 'lodash/filter';
 import ContentLoader from 'react-content-loader';
 
+import SourceExpandedView from './SourceExpandedView';
 import { loadEntities, selectEntity, expandEntity, removeSource, sortEntities } from '../redux/actions/providers';
 
 const RowLoader = props => (
@@ -53,11 +54,11 @@ class SourcesSimpleView extends React.Component {
                 direction
             }
         });
-    }
+    };
 
-    onExpandClick = (_event, _row, rowKey) => this.props.expandEntity(rowKey, true);
+    onCollapse = (_event, i, isOpen) => this.props.expandEntity(this.sourceIndexToId(i), isOpen);
 
-    sourceIndexToId = (i) => this.props.entities[i].id;
+    sourceIndexToId = (i) => this.props.entities[i / 2].id;
 
     renderActions = () => (
         [
@@ -79,12 +80,30 @@ class SourcesSimpleView extends React.Component {
             col => (col.formatter ?
                 this[col.formatter](item[col.value]) :
                 item[col.value] || ''));
-    }
+    };
 
     render = () => {
         const { entities, loaded, sourceTypes } = this.props;
-        const rowData = flatten(entities.map(item => (
-            [{ ...item, cells: this.itemToCells(item) }]
+        const rowData = flatten(entities.map((item, index) => (
+            [
+                { // regular item
+                    ...item,
+                    isOpen: !!item.expanded,
+                    cells: this.itemToCells(item)
+                },
+                { // expanded content
+                    id: item.id + '_detail',
+                    parent: index * 2,
+                    cells: [
+                        {
+                            title: item.expanded ?
+                                <SourceExpandedView sourceId={item.id}/> :
+                                'collapsed content',
+                            colSpan: this.filteredColumns.length + 1
+                        }
+                    ]
+                }
+            ]
         )));
 
         this.sourceTypeMap = new Map(sourceTypes.map(t => [t.id, t.name]));
@@ -114,7 +133,7 @@ class SourcesSimpleView extends React.Component {
                 </tbody>
             </table>
         );
-    }
+    };
 };
 
 SourcesSimpleView.propTypes = {

--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -4,7 +4,14 @@ import { connect } from 'react-redux';
 import { Link, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { PageHeader, PageHeaderTitle, Pagination, Section } from '@red-hat-insights/insights-frontend-components';
-import { addProvider, createSource, filterProviders, loadEntities, loadSourceTypes } from '../redux/actions/providers';
+import {
+    addProvider,
+    createSource,
+    filterProviders,
+    loadEntities,
+    loadSourceTypes,
+    setProviderFilterColumn
+} from '../redux/actions/providers';
 import { Button } from '@patternfly/react-core';
 import { Card, CardBody, CardFooter, CardHeader, Modal } from '@patternfly/react-core';
 import filter from 'lodash/filter';
@@ -31,6 +38,7 @@ class SourcesPage extends Component {
         addProvider: PropTypes.func.isRequired,
         createSource: PropTypes.func.isRequired,
         filterProviders: PropTypes.func.isRequired,
+        setProviderFilterColumn: PropTypes.func.isRequired,
         loadEntities: PropTypes.func.isRequired,
         loadSourceTypes: PropTypes.func.isRequired,
         pageAndSize: PropTypes.func.isRequired,
@@ -67,9 +75,14 @@ class SourcesPage extends Component {
         });
     }
 
-    onFilter = (filterColumn, filterValue) => {
-        console.log('onFilter', filterColumn, filterValue);
-        this.props.filterProviders(filterColumn, filterValue);
+    onFilter = (filterValue) => {
+        console.log('onFilter', filterValue);
+        this.props.filterProviders(filterValue);
+    }
+
+    onFilterSelect = (_component, column) => {
+        console.log('onFilter', column);
+        this.props.setProviderFilterColumn(column.value);
     }
 
     onSetPage = (number) => {
@@ -92,7 +105,8 @@ class SourcesPage extends Component {
             <CardHeader>
                 <SourcesFilter
                     columns={filter(sourcesViewDefinition.columns, c => c.searchable)}
-                    onFilter={this.onFilter}/>
+                    onFilter={this.onFilter}
+                    onFilterSelect={this.onFilterSelect}/>
             </CardHeader>
             <CardBody>
                 <SourcesSimpleView columns={sourcesViewDefinition.columns}/>
@@ -148,7 +162,7 @@ class SourcesPage extends Component {
 
 const mapDispatchToProps = dispatch => bindActionCreators(
     { addProvider, createSource, filterProviders, loadEntities,
-        loadSourceTypes, pageAndSize }, dispatch);
+        loadSourceTypes, pageAndSize, setProviderFilterColumn }, dispatch);
 
 const mapStateToProps = ({ providers: { loaded, numberOfEntities, sourceTypes } }) => ({ loaded, numberOfEntities, sourceTypes });
 

--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -43,9 +43,10 @@ class SourcesPage extends Component {
         loadSourceTypes: PropTypes.func.isRequired,
         pageAndSize: PropTypes.func.isRequired,
 
+        filterValue: PropTypes.string,
+        loaded: PropTypes.bool.isRequired,
         numberOfEntities: PropTypes.number.isRequired,
         sourceTypes: PropTypes.arrayOf(PropTypes.any),
-        loaded: PropTypes.bool.isRequired,
 
         location: PropTypes.any.isRequired,
         history: PropTypes.any.isRequired
@@ -127,7 +128,9 @@ class SourcesPage extends Component {
     render = () => {
         const { numberOfEntities } = this.props;
         const form = wizardForm(this.props.sourceTypes || []);
-        const displayEmptyState = this.props.loaded && (!numberOfEntities || numberOfEntities === 0);
+        const displayEmptyState = this.props.loaded &&
+            !this.props.filterValue &&
+            (!numberOfEntities || numberOfEntities === 0);
 
         return (
             <React.Fragment>
@@ -164,6 +167,8 @@ const mapDispatchToProps = dispatch => bindActionCreators(
     { addProvider, createSource, filterProviders, loadEntities,
         loadSourceTypes, pageAndSize, setProviderFilterColumn }, dispatch);
 
-const mapStateToProps = ({ providers: { loaded, numberOfEntities, sourceTypes } }) => ({ loaded, numberOfEntities, sourceTypes });
+const mapStateToProps = ({ providers: { filterValue, loaded, numberOfEntities, sourceTypes } }) => (
+    { filterValue, loaded, numberOfEntities, sourceTypes }
+);
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(SourcesPage));

--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -4,15 +4,13 @@ import { connect } from 'react-redux';
 import { Link, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { PageHeader, PageHeaderTitle, Pagination, Section } from '@red-hat-insights/insights-frontend-components';
-
-//import './provider-page.scss';
 import { addProvider, createSource, filterProviders, loadEntities, loadSourceTypes } from '../redux/actions/providers';
-
 import { Button } from '@patternfly/react-core';
-import { Card, CardBody, CardFooter, Modal } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Modal } from '@patternfly/react-core';
+import filter from 'lodash/filter';
 
 import SourcesSimpleView from '../components/SourcesSimpleView';
-//import SourcesFilter from '../components/SourcesFilter';
+import SourcesFilter from '../components/SourcesFilter';
 import SourcesEmptyState from '../components/SourcesEmptyState';
 
 import { sourcesViewDefinition } from '../views/sourcesViewDefinition';
@@ -91,9 +89,11 @@ class SourcesPage extends Component {
 
     renderMainContent = () => (
         <Card>
-            {/*<CardHeader>
-                <SourcesFilter columns={filterColumns} onFilter={this.onFilter}/>
-            </CardHeader>*/}
+            <CardHeader>
+                <SourcesFilter
+                    columns={filter(sourcesViewDefinition.columns, c => c.searchable)}
+                    onFilter={this.onFilter}/>
+            </CardHeader>
             <CardBody>
                 <SourcesSimpleView columns={sourcesViewDefinition.columns}/>
             </CardBody>
@@ -108,10 +108,9 @@ class SourcesPage extends Component {
                 />
             </CardFooter>
         </Card>
-    )
+    );
 
     render = () => {
-        // const filterColumns = filter(providerColumns, c => c.value);
         const { numberOfEntities } = this.props;
         const form = wizardForm(this.props.sourceTypes || []);
         const displayEmptyState = this.props.loaded && (!numberOfEntities || numberOfEntities === 0);

--- a/src/redux/action-types-providers.js
+++ b/src/redux/action-types-providers.js
@@ -24,5 +24,6 @@ export const SORT_ENTITIES = 'SORT_ENTITIES';
 export const PAGE_AND_SIZE = 'PAGE_AND_SIZE';
 export const ADD_PROVIDER  = 'ADD_PROVIDER';
 export const FILTER_PROVIDERS  = 'FILTER_PROVIDERS';
+export const SET_FILTER_COLUMN = 'SET_FILTER_COLUMN';
 export const CLOSE_ALERT  = 'CLOSE_ALERT';
 export const ADD_ALERT  = 'ADD_ALERT';

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -1,6 +1,6 @@
 import {
     ACTION_TYPES, SELECT_ENTITY, EXPAND_ENTITY, SORT_ENTITIES, PAGE_AND_SIZE,
-    ADD_PROVIDER, FILTER_PROVIDERS, CLOSE_ALERT, ADD_ALERT
+    ADD_PROVIDER, FILTER_PROVIDERS, CLOSE_ALERT, ADD_ALERT, SET_FILTER_COLUMN
 } from '../action-types-providers';
 import { getEntities, doCreateSource, doRemoveSource } from '../../api/entities';
 import { doLoadSourceTypes } from '../../api/source_types';
@@ -35,9 +35,14 @@ export const addProvider = (formData) => ({
     payload: { formData }
 });
 
-export const filterProviders = (column, value) => ({
+export const filterProviders = (value) => ({
     type: FILTER_PROVIDERS,
-    payload: { column, value }
+    payload: { value }
+});
+
+export const setProviderFilterColumn = (column) => ({
+    type: SET_FILTER_COLUMN,
+    payload: { column }
 });
 
 export const closeAlert = () => ({

--- a/src/redux/reducers/providers.js
+++ b/src/redux/reducers/providers.js
@@ -1,6 +1,7 @@
 import {
     ACTION_TYPES, SELECT_ENTITY, EXPAND_ENTITY, SORT_ENTITIES,
-    PAGE_AND_SIZE, ADD_PROVIDER, FILTER_PROVIDERS//, CLOSE_ALERT, ADD_ALERT
+    PAGE_AND_SIZE, ADD_PROVIDER, FILTER_PROVIDERS, SET_FILTER_COLUMN
+    //, CLOSE_ALERT, ADD_ALERT
 } from '../action-types-providers';
 import { processList } from '../../Utilities/listHelpers';
 
@@ -84,11 +85,17 @@ const addProvider = (state, { payload: { formData } }) => {
     };
 };
 
-const filterProviders = (state, { payload: { column, value } }) =>
+const filterProviders = (state, { payload: { value } }) =>
+    processListInState({
+        ...state,
+        filterValue: value,
+        pageNumber: 1
+    });
+
+const setFilterColumn = (state, { payload: { column } }) =>
     processListInState({
         ...state,
         filterColumn: column,
-        filterValue: value,
         pageNumber: 1
     });
 
@@ -135,7 +142,8 @@ export default {
     [SORT_ENTITIES]: sortEntities,
     [PAGE_AND_SIZE]: setPageAndSize,
     [ADD_PROVIDER]: addProvider,
-    [FILTER_PROVIDERS]: filterProviders
+    [FILTER_PROVIDERS]: filterProviders,
+    [SET_FILTER_COLUMN]: setFilterColumn
 //    [CLOSE_ALERT]: closeAlert,
 //    [ADD_ALERT]: addAlert,
 };

--- a/src/views/sourcesViewDefinition.js
+++ b/src/views/sourcesViewDefinition.js
@@ -10,10 +10,10 @@ export const sourcesViewDefinition = {
         //{ title: null, value: 'source_ref', },
         //{ title: 'Resource version', value: 'resource_version', },
         { title: 'UID', value: 'uid' },
-        { title: 'Name', value: 'name' },
-        { title: 'Source Type', value: 'source_type_id', formatter: 'sourceTypeFormatter' },
+        { title: 'Name', value: 'name', searchable: true },
+        { title: 'Source Type', value: 'source_type_id', searchable: true, formatter: 'sourceTypeFormatter' },
         // this column does not actually exist in the API, but is required by the design
-        { title: 'Applications', value: 'applications' },
+        { title: 'Applications', value: 'applications', searchable: true },
         //{ title: 'Tags', value: 'tags', },
         //{ title: null, value: 'display_name', },
         //{ title: 'Created at', value: 'created_at', },


### PR DESCRIPTION
~~To be rebased when https://github.com/ManageIQ/sources-ui/pull/31 is merged.~~ (done)

  * Add filtering UI.
  * Add row expansion UI.
  * Removed demo content from the expanded view.

For now all is client-based. Server side pagination and filtering is to be done in a separate PR.

Only Filtering on "Name" works for now as that is the only attribute (out of Name, Source type and Applications) that has simple string value that can be simply filtered.

![filter-ui](https://user-images.githubusercontent.com/51095/55398547-1b452280-5549-11e9-8b70-1a11dfd3dc4d.png)
