### PR TITLE
Switch to using sources-api service

### DIFF
--- a/src/Utilities/Constants.js
+++ b/src/Utilities/Constants.js
@@ -8,7 +8,7 @@
  * Else append the microservice path and version. This behavior is compatible with Service Catalog.
  */
 const calculateApiBase = b => (
-    (b.endsWith('/') && `${b}v0.1`) || `${b}/topological-inventory/v0.1`
+    (b.endsWith('/') && `${b}v1.0`) || `${b}/sources/v1.0`
 );
 
-export const TOPOLOGICAL_INVENTORY_API_BASE = calculateApiBase(process.env.BASE_PATH || '');
+export const SOURCES_API_BASE = calculateApiBase(process.env.BASE_PATH || '');

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -1,4 +1,4 @@
-import { TOPOLOGICAL_INVENTORY_API_BASE } from '../Utilities/Constants';
+import { SOURCES_API_BASE } from '../Utilities/Constants';
 import { sourcesViewDefinition } from '../views/sourcesViewDefinition';
 import find from 'lodash/find';
 
@@ -14,12 +14,12 @@ export function getApiInstance() {
 
     apiInstance = new TopologicalInventory.DefaultApi();
     let defaultClient = TopologicalInventory.ApiClient.instance;
-    defaultClient.basePath = TOPOLOGICAL_INVENTORY_API_BASE;
+    defaultClient.basePath = SOURCES_API_BASE;
     return apiInstance;
 }
 
 export function getEntities (_pagination, _filter) {
-    return fetch(TOPOLOGICAL_INVENTORY_API_BASE + sourcesViewDefinition.url).then(r => {
+    return fetch(SOURCES_API_BASE + sourcesViewDefinition.url).then(r => {
         if (r.ok || r.type === 'opaque') {
             return r.json();
         }

--- a/src/api/source_types.js
+++ b/src/api/source_types.js
@@ -1,8 +1,8 @@
-import { TOPOLOGICAL_INVENTORY_API_BASE } from '../Utilities/Constants';
+import { SOURCES_API_BASE } from '../Utilities/Constants';
 // import { getApiInstance } from './entities.js';
 
 export function doLoadSourceTypes() {
-    return fetch(TOPOLOGICAL_INVENTORY_API_BASE + '/source_types/')
+    return fetch(SOURCES_API_BASE + '/source_types/')
     .then(r => r.json())
     .then(data => data.data);
 

--- a/src/test/SourcesPage.spec.js
+++ b/src/test/SourcesPage.spec.js
@@ -12,7 +12,7 @@ import { sourcesData } from './sourcesData';
 import { sourceTypesData } from './sourceTypesData';
 
 import { MemoryRouter } from 'react-router-dom';
-import { TOPOLOGICAL_INVENTORY_API_BASE } from '../Utilities/Constants';
+import { SOURCES_API_BASE } from '../Utilities/Constants';
 
 describe('SourcesPage', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -37,8 +37,8 @@ describe('SourcesPage', () => {
     it('should fetch sources and source types on component mount', (done) => {
         expect.assertions(1);
         const store = mockStore(initialState);
-        fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/`, { data: {} });
-        fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/source_types/`, { data: {} });
+        fetchMock.getOnce(`${SOURCES_API_BASE}/sources/`, { data: {} });
+        fetchMock.getOnce(`${SOURCES_API_BASE}/source_types/`, { data: {} });
 
         const expectedActions = [
             { type: 'LOAD_SOURCE_TYPES_PENDING' },
@@ -56,8 +56,8 @@ describe('SourcesPage', () => {
 
     it('renders empty state when there are no Sources', (done) => {
         const store = mockStore(initialState);
-        fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/`, sourcesData);
-        fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/source_types/`, sourceTypesData);
+        fetchMock.getOnce(`${SOURCES_API_BASE}/sources/`, sourcesData);
+        fetchMock.getOnce(`${SOURCES_API_BASE}/source_types/`, sourceTypesData);
 
         const page = mount(<ComponentWrapper store={ store }><SourcesPage { ...initialProps } /></ComponentWrapper>);
         setImmediate(() => {
@@ -70,8 +70,8 @@ describe('SourcesPage', () => {
         const store = mockStore({
             providers: { loaded: true, rows: [], entities: [], numberOfEntities: 1 }
         });
-        fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/`, sourcesData);
-        fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/source_types/`, sourceTypesData);
+        fetchMock.getOnce(`${SOURCES_API_BASE}/sources/`, sourcesData);
+        fetchMock.getOnce(`${SOURCES_API_BASE}/source_types/`, sourceTypesData);
 
         const page = mount(<ComponentWrapper store={ store }><SourcesPage { ...initialProps } /></ComponentWrapper>);
 


### PR DESCRIPTION
Point the sources-ui to the sources-api service instead of the topological-inventory-api