### PR TITLE
Wait for SSO before firing an API request.

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -6,6 +6,10 @@ import { sourcesViewDefinition } from '../views/sourcesViewDefinition';
 import { SOURCES_API_BASE } from '../Utilities/Constants';
 
 const axiosInstance = axios.create();
+axiosInstance.interceptors.response.use(async (config) => {
+    await window.insights.chrome.auth.getUser();
+    return config;
+});
 axiosInstance.interceptors.response.use(response => response.data || response);
 axiosInstance.interceptors.response.use(null, error => { throw { ...error.response }; });
 


### PR DESCRIPTION
prevent API calls before the SSO is done.

credits: @karelhala 

ping @Hyperkid123 