### PR TITLE
Use the API client for the list of source_types.

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -7,8 +7,10 @@ const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docke
 module.exports = {
     routes: {
         '/insights/settings/sources': { host: `http://${localhost}:8002` },
-        '/hybrid/settings/catalog-sources': { host: `http://${localhost}:8002` },
-        '/hybrid/settings/cost-management-sources': { host: `http://${localhost}:8002` },
+        '/hybrid/settings/sources': { host: `http://${localhost}:8002` },
+
+        //'/hybrid/settings/catalog-sources': { host: `http://${localhost}:8002` },
+        //'/hybrid/settings/cost-management-sources': { host: `http://${localhost}:8002` },
         '/apps/sources': { host: `http://${localhost}:8002` }
         // '/apps/chrome': { host: 'https://ci.cloud.paas.upshift.redhat.com' } // use non-local chrome
     }

--- a/src/api/source_types.js
+++ b/src/api/source_types.js
@@ -1,27 +1,5 @@
-import { SOURCES_API_BASE } from '../Utilities/Constants';
-// import { getApiInstance } from './entities.js';
+import { getSourcesApi } from './entities.js';
 
 export function doLoadSourceTypes() {
-    return fetch(SOURCES_API_BASE + '/source_types/')
-    .then(r => r.json())
-    .then(data => data.data);
-
-    /*  FIXME: the API is broken now, data is returned as "Object object" so switching
-     *  to fetch() for now.
-     *
-     *  let opts = {
-     *      limit: 100,
-     *      offset: 0
-     *  };
-     *
-     *  return getApiInstance().listSourceTypes(opts).then((data) => {
-     *      console.log('data: ', data.data);
-     *      return data.data;
-     *  }, (error) => {
-     *      console.error(error);
-     *      return [];
-     *  });
-    */
+    return getSourcesApi().listSourceTypes().then(data => data.data);
 }
-
-;

--- a/src/test/SourcesPage.spec.js
+++ b/src/test/SourcesPage.spec.js
@@ -38,7 +38,7 @@ describe('SourcesPage', () => {
         expect.assertions(1);
         const store = mockStore(initialState);
         apiClientMock.get(`${SOURCES_API_BASE}/sources/`, mockOnce({ body: { data: sourcesData } }));
-        fetchMock.getOnce(`${SOURCES_API_BASE}/source_types/`, sourceTypesData);
+        apiClientMock.get(`${SOURCES_API_BASE}/source_types`, mockOnce({ body: { data: sourceTypesData } }));
 
         const expectedActions = [
             { type: 'LOAD_SOURCE_TYPES_PENDING' },
@@ -57,7 +57,7 @@ describe('SourcesPage', () => {
     it('renders empty state when there are no Sources', (done) => {
         const store = mockStore(initialState);
         apiClientMock.get(`${SOURCES_API_BASE}/sources/`, mockOnce({ body: { data: sourcesData } }));
-        fetchMock.getOnce(`${SOURCES_API_BASE}/source_types/`, sourceTypesData);
+        apiClientMock.get(`${SOURCES_API_BASE}/source_types`, mockOnce({ body: { data: sourceTypesData } }));
 
         const page = mount(<ComponentWrapper store={ store }><SourcesPage { ...initialProps } /></ComponentWrapper>);
         setImmediate(() => {
@@ -71,7 +71,7 @@ describe('SourcesPage', () => {
             providers: { loaded: true, rows: [], entities: [], numberOfEntities: 1 }
         });
         apiClientMock.get(`${SOURCES_API_BASE}/sources/`, mockOnce({ body: { data: sourcesData } }));
-        fetchMock.getOnce(`${SOURCES_API_BASE}/source_types/`, sourceTypesData);
+        apiClientMock.get(`${SOURCES_API_BASE}/source_types`, mockOnce({ body: { data: sourceTypesData } }));
 
         const page = mount(<ComponentWrapper store={ store }><SourcesPage { ...initialProps } /></ComponentWrapper>);
 


### PR DESCRIPTION
This should finally fix the problem with firing API request before the user is authenticated properly because the API client is using Axios and for Axios there's an interceptor set to wait for `...auth.getUser()`