### PR TITLE
Add loading modal for source edit

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -48,6 +48,11 @@
   }
 }
 
+.ins-c-sources__dialog--spinnerContainer {
+  min-height: 64px;
+  text-align: center;
+}
+
 /* temporary styling for wizard buttons in the form player */
 .wizard-button-toolbar {
   justify-content: flex-start !important;

--- a/src/components/SourceEditModal.js
+++ b/src/components/SourceEditModal.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import { Modal } from '@patternfly/react-core';
+import { Spinner } from '@red-hat-insights/insights-frontend-components';
 
 import { sourceEditForm, sourceNewForm } from '../SmartComponents/ProviderPage/providerForm';
 import SourcesFormRenderer from '../Utilities/SourcesFormRenderer';
@@ -35,7 +36,15 @@ const SourceEditModal = props => {
     };
 
     if (!props.sourceTypes || (!editorNew && !props.source)) {
-        return <div>Loading...</div>;
+        return <Modal
+            title={editorNew ? 'Add a source' : 'Edit Source'}
+            isOpen
+            onClose={props.history.goBack}
+            isLarge>
+            <div className="ins-c-sources__dialog--spinnerContainer">
+                <Spinner />
+            </div>
+        </Modal>;
     }
 
     const form = editorNew ?


### PR DESCRIPTION
**Description**

- adds modal placeholder when user is waiting for editing a source
- user can cancel the action by pressing cancel icon in the modal

**Before**

![beforeLoadingModal](https://user-images.githubusercontent.com/32869456/58237156-b934bc80-7d44-11e9-9c61-538a452e06d3.gif)


**After**

![loadingState](https://user-images.githubusercontent.com/32869456/58237077-960a0d00-7d44-11e9-8e9e-69b9987b9c5b.gif)


@martinpovolny 