### PR TITLE
Make delete button in danger color

### DIFF
--- a/src/components/SourcesSimpleView.js
+++ b/src/components/SourcesSimpleView.js
@@ -74,6 +74,7 @@ class SourcesSimpleView extends React.Component {
             },
             {
                 title: 'Delete',
+                style: { color: 'var(--pf-global--danger-color--100)' },
                 onClick: (_ev, i) => this.props.history.push(`/remove/${this.sourceIndexToId(i)}`)
             }
         ]


### PR DESCRIPTION
**Description**

In other parts of Cloud Services, delete buttons are in danger color.

**Before**

![image](https://user-images.githubusercontent.com/32869456/58237907-7d9af200-7d46-11e9-94f9-e9ee8026c575.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/58237893-77a51100-7d46-11e9-88a8-d589b0c7512b.png)


@martinpovolny 