### PR TITLE
Use username as a field name instead of user_name,user

### DIFF
--- a/src/SmartComponents/ProviderPage/providerForm.js
+++ b/src/SmartComponents/ProviderPage/providerForm.js
@@ -241,7 +241,7 @@ const temporaryHardcodedSourceSchemas = {
             initialValue: 'access_key_secret_key'
         }, {
             component: componentTypes.TEXT_FIELD,
-            name: 'user_name',
+            name: 'username',
             label: <FormattedMessage
                 id="sources.accesKeyID"
                 defaultMessage="Access Key ID"
@@ -476,7 +476,7 @@ const initialValues = source => {
         certificate_authority,
         role,
         token: '',      // never loaded (part of authentication)
-        user_name: '',  // never loaded (part of authentication)
+        username: '',  // never loaded (part of authentication)
         password: ''    // same as token
     };
 };

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -173,10 +173,12 @@ export function doUpdateSource(source, formData) {
     .then((_sourceDataOut) => {
         const { scheme, host, port, path } = urlOrHost(formData);
 
+        const endPointPort = parseInt(port, 10);
+
         const endpointData = {
             scheme,
             host,
-            port: String(parseInt(port, 10)),
+            port: isNaN(endPointPort) ? undefined : endPointPort,
             path,
             verify_ssl: formData.verify_ssl,
             certificate_authority: formData.certificate_authority

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -140,7 +140,7 @@ export function doCreateSource(formData, sourceTypes) {
             const authenticationData = {
                 resource_id: String(parseInt(endpointDataOut.id, 10)),
                 resource_type: 'Endpoint',
-                username: formData.user_name,
+                username: formData.username,
                 password: formData.token || formData.password,
                 authtype: formData.authtype
             };
@@ -176,7 +176,7 @@ export function doUpdateSource(source, formData) {
         const endpointData = {
             scheme,
             host,
-            port: parseInt(port, 10),
+            port: String(parseInt(port, 10)),
             path,
             verify_ssl: formData.verify_ssl,
             certificate_authority: formData.certificate_authority
@@ -185,7 +185,7 @@ export function doUpdateSource(source, formData) {
         return inst.updateEndpoint(source.endpoint.id, endpointData)
         .then((_endpointDataOut) => {
             const authenticationData = {
-                username: formData.user_name,
+                username: formData.username,
                 password: formData.token || formData.password // FIXME: unify
             };
 

--- a/src/components/SourceWizardSummary.js
+++ b/src/components/SourceWizardSummary.js
@@ -43,7 +43,7 @@ openShiftSummary.propTypes = {
     certificate_authority: PropTypes.string.isRequired
 };
 
-const awsSummary = ({ user_name, password }) => (
+const awsSummary = ({ username, password }) => (
     <React.Fragment>
         <FormGroup
             label = {<FormattedMessage
@@ -56,7 +56,7 @@ const awsSummary = ({ user_name, password }) => (
                 isDisabled
                 type="text"
                 id="summary-id"
-                value={user_name}
+                value={username}
             />
         </FormGroup>
         <FormGroup
@@ -76,7 +76,7 @@ const awsSummary = ({ user_name, password }) => (
     </React.Fragment>
 );
 awsSummary.propTypes = {
-    user_name: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
     password: PropTypes.string.isRequired
 };
 


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/TPINVTRY-533

Changes according to https://github.com/ManageIQ/sources-api/pull/57/files

**Description**

- username field is alwasy named `username` (not _user_name_, _user,_ etc.)
- changed due to changes in API (better consistency)
- also added a check if port is a number (missed last time)

@agrare @martinpovolny @gtanzillo 