### PR TITLE
Fix missing attribute to display source type

### DIFF
--- a/src/components/SourcesSimpleView.js
+++ b/src/components/SourcesSimpleView.js
@@ -119,8 +119,10 @@ class SourcesSimpleView extends React.Component {
         );
     }
 
-    sourceTypeFormatter = sourceType =>
-        (this.props.sourceTypes.find((type) => type.id === sourceType) || sourceType || '');
+    sourceTypeFormatter = sourceType => {
+        const type = this.props.sourceTypes.find((type) => type.id === sourceType);
+        return type.product_name || sourceType || '';
+    }
 
     dateFormatter = str => moment(new Date(Date.parse(str))).utc().format('DD MMM YYYY, hh:mm UTC');
     nameFormatter = (name, source) => (


### PR DESCRIPTION
Something I missed the all time

**Before**

![image](https://user-images.githubusercontent.com/32869456/63028831-d1355b80-beaf-11e9-8872-2e4ac869eaa8.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/63028798-c4186c80-beaf-11e9-9ad8-4b6c976dcd62.png)


@miq-bot add_label