### PR TITLE
Add connected apps link when deleting source with apps

### DIFF
--- a/src/components/SourceRemoveModal.js
+++ b/src/components/SourceRemoveModal.js
@@ -85,12 +85,18 @@ const SourceRemoveModal = ({
                     applications have been removed from this source."
                 />
             </Text>
-            <Text component={ TextVariants.p } style={{ marginBottom: 0 }}>
-                <FormattedMessage
-                    id="sources.connectedApps"
-                    defaultMessage="Connected applications:"
-                />
-            </Text>
+            <Button
+                variant="link"
+                isInline
+                onClick={ (_ev) => push(`/manage_apps/${source.id}`)}
+            >
+                <Text component={ TextVariants.p } style={{ marginBottom: 0 }}>
+                    <FormattedMessage
+                        id="sources.connectedApps"
+                        defaultMessage="Connected applications:"
+                    />
+                </Text>
+            </Button>
             { appNames }
         </React.Fragment>
     ) : (

--- a/src/test/SourceRemoveModal.spec.js
+++ b/src/test/SourceRemoveModal.spec.js
@@ -4,7 +4,8 @@ import { mount } from 'enzyme';
 import { notificationsMiddleware } from '@red-hat-insights/insights-frontend-components/components/Notifications';
 import { Route } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
-import { Text } from '@patternfly/react-core';
+import { Text, Button } from '@patternfly/react-core';
+import { MemoryRouter } from 'react-router-dom';
 import * as redux from 'redux';
 
 import * as actions from '../redux/actions/providers';
@@ -34,7 +35,7 @@ describe('SourceRemoveModal', () => {
             );
 
             expect(wrapper.find('input')).toHaveLength(1); // checkbox
-            expect(wrapper.find('button')).toHaveLength(3); // cancel modal, cancel delete, delete
+            expect(wrapper.find(Button)).toHaveLength(3); // cancel modal, cancel delete, delete
             expect(wrapper.find('button[id="deleteSubmit"]').props().disabled).toEqual(true); // delete is disabled
         });
 
@@ -86,8 +87,20 @@ describe('SourceRemoveModal', () => {
             const application = applicationTypesData.data.find((app) => app.id === source.applications[0].application_type_id);
 
             expect(wrapper.find('input')).toHaveLength(0); // checkbox
-            expect(wrapper.find('button')).toHaveLength(2); // cancel modal, cancel delete
+            expect(wrapper.find(Button)).toHaveLength(3); // cancel modal, cancel delete, connected apps
             expect(wrapper.find(Text).at(2).text().includes(application.display_name)).toEqual(true); // application in the list
+        });
+
+        it('clicks on connected apps', () => {
+            const wrapper = mount(componentWrapperIntl(
+                <Route path="/remove/:id" render={ (...args) => <SourceRemoveModal { ...args } /> } />,
+                store,
+                ['/remove/406'])
+            );
+
+            wrapper.find(Button).at(1).simulate('click'); // Click on redirect
+
+            expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual('/manage_apps/406');
         });
     });
 });


### PR DESCRIPTION
**Description**

Connected apps is now link which leads... to connected apps! :tada: :taco: :tada: 

![connected_apps](https://user-images.githubusercontent.com/32869456/63522980-9b205900-c4f9-11e9-959c-9b2a35c97ad6.gif)
(mouse is missing :mouse: :dagger: :skull_and_crossbones: )

@terezanovotna @Hyperkid123 