### PR TITLE
Fix selecting the right index for a source

### DIFF
--- a/src/components/SourcesSimpleView.js
+++ b/src/components/SourcesSimpleView.js
@@ -55,7 +55,7 @@ class SourcesSimpleView extends React.Component {
         });
     };
 
-    sourceIndexToId = (i) => this.props.entities[i / 2].id;
+    sourceIndexToId = (i) => this.props.entities[i].id;
 
     renderActions = () => (
         [{


### PR DESCRIPTION
**Description**
During the cleanup (https://github.com/ManageIQ/sources-ui/pull/92), the hidden rows was deleted, however, indexes weren't updated properly.


@miq-bot add_label bug

@Hyperkid123 