### PR TITLE
Do not show empty/default ports

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -3,6 +3,7 @@ import { DefaultApi as SourcesDefaultApi } from '@redhat-cloud-services/sources-
 import { Base64 } from 'js-base64';
 
 import { SOURCES_API_BASE } from '../Utilities/Constants';
+import { defaultPort } from '../components/SourcesSimpleView/formatters';
 
 const axiosInstance = axios.create(
     process.env.FAKE_IDENTITY ? {
@@ -41,31 +42,28 @@ export function doRemoveSource(sourceId) {
     });
 }
 
-export function doLoadSourceForEdit(sourceId) {
-    return getSourcesApi().showSource(sourceId).then(sourceData => {
-        return getSourcesApi().listSourceEndpoints(sourceId, {}).then(endpoints => {
-            // we take just the first endpoint
-            const endpoint = endpoints && endpoints.data && endpoints.data[0];
+export const doLoadSourceForEdit = sourceId => Promise.all([
+    getSourcesApi().showSource(sourceId),
+    getSourcesApi().listSourceEndpoints(sourceId, {})
+]).then(([sourceData, endpoints]) => {
+    const endpoint = endpoints && endpoints.data && endpoints.data[0];
 
-            if (!endpoint) { // bail out
-                return sourceData;
-            }
+    if (!endpoint) { // bail out
+        return sourceData;
+    }
 
-            sourceData.endpoint = endpoint;
+    sourceData.endpoint = endpoint;
 
-            return getSourcesApi().listEndpointAuthentications(endpoint.id, {}).then(authentications => {
-                // we take just the first authentication
-                const authentication = authentications && authentications.data && authentications.data[0];
+    return getSourcesApi().listEndpointAuthentications(endpoint.id, {}).then(authentications => {
+        const authentication = authentications && authentications.data && authentications.data[0];
 
-                if (authentication) {
-                    sourceData.authentication = authentication;
-                }
+        if (authentication) {
+            sourceData.authentication = authentication;
+        }
 
-                return { ...sourceData, source: { name: sourceData.name } };
-            });
-        });
+        return { ...sourceData, source: { name: sourceData.name } };
     });
-}
+});
 
 const parseUrl = url => {
     if (!url) {
@@ -77,7 +75,7 @@ const parseUrl = url => {
         return {
             scheme: u.protocol.replace(/:$/, ''),
             host: u.hostname,
-            port: u.port,
+            port: u.port === '' ? defaultPort(u.protocol.replace(/:$/, '')) : u.port,
             path: u.pathname
         };
     } catch (error) {
@@ -85,65 +83,47 @@ const parseUrl = url => {
     }
 };
 
-/*
- * If there's an URL in the formData, parse it and use it,
- * else use individual fields (scheme, host, port, path).
- */
-const urlOrHost = formData => formData.url ? parseUrl(formData.url) : formData;
+const urlOrHost = formData => formData.url ? parseUrl(formData.url) : formData.endpoint ? formData.endpoint : formData;
 
-export function doUpdateSource(source, formData) {
-    return getSourcesApi().updateSource(source.id, formData.source)
-    .then((_sourceDataOut) => {
-        const { scheme, host, port, path } = urlOrHost(formData.endpoint);
+export const doUpdateSource = (source, formData) => {
+    const { scheme, host, port, path } = urlOrHost(formData);
+    const endPointPort = parseInt(port, 10);
 
-        const endPointPort = parseInt(port, 10);
+    const endpointData = {
+        scheme,
+        host,
+        path,
+        port: isNaN(endPointPort) ? undefined : endPointPort,
+        ...formData.endpoint
+    };
 
-        const endpointData = {
-            scheme,
-            host,
-            port: isNaN(endPointPort) ? undefined : endPointPort,
-            path,
-            ...formData.endpoint
-        };
-
-        return getSourcesApi().updateEndpoint(source.endpoint.id, endpointData)
-        .then((_endpointDataOut) => {
-            return getSourcesApi().updateAuthentication(source.authentication.id, 'formData.authentication')
-            .then((authenticationDataOut) => {
-                return authenticationDataOut;
-            }, (error) => {
-                throw { error: { title: 'Authentication update failure.', detail: error.data } };
-            });
-        }, (error) => {
+    return Promise.all([
+        getSourcesApi().updateSource(source.id, formData.source).catch((error) => {
+            throw { error: { title: 'Source update failure.', detail: error.data } };
+        }),
+        getSourcesApi().updateEndpoint(source.endpoint.id, endpointData).catch((error) => {
             throw { error: { title: 'Endpoint update failure.', detail: error.data } };
-        });
+        }),
+        getSourcesApi().updateAuthentication(source.authentication.id, formData.authentication).catch((error) => {
+            throw { error: { title: 'Authentication update failure.', detail: error.data } };
+        })
+    ]);
+};
 
-    }, (error) => {
-        throw { error: { title: 'Source update failure.', detail: error.data } };
-    });
-}
-
-/* Source type limitation by location (URL). Now disabled.
- *
- *  export const sourceTypeStrFromLocation = () => (
- *      window.appGroup === 'insights' ? 'amazon' :
- *          window.appGroup === 'hybrid' ? 'openshift' : null
- * );
- */
-export const sourceTypeStrFromLocation = () => null;
-
-// Loads all sources with endpoints and applications infor
 export const doLoadEntities = () => getSourcesApi().postGraphQL({
     query: `{ sources
-        { id,
-          created_at,
-          source_type_id,
-          name,
-          tenant,
-          uid,
-          updated_at
-          applications { application_type_id, id },
-          endpoints { id, scheme, host, port, path } }}`
+        {
+            id,
+            created_at,
+            source_type_id,
+            name,
+            tenant,
+            uid,
+            updated_at
+            applications { application_type_id, id },
+            endpoints { id, scheme, host, port, path }
+        }
+    }`
 }).then(({ data }) => data);
 
 export const doCreateApplication = (source_id, application_type_id) => getSourcesApi().createApplication({

--- a/src/components/SourcesSimpleView/formatters.js
+++ b/src/components/SourcesSimpleView/formatters.js
@@ -2,7 +2,16 @@ import React from 'react';
 import moment from 'moment';
 import { Text, TextContent, TextVariants } from '@patternfly/react-core';
 
-import { endpointToUrl } from '../../components/SourceEditForm/editSourceSchema';
+export const defaultPort = (scheme) => ({
+    http: '80',
+    https: '443'
+}[scheme]);
+
+export const schemaToPort = (schema, port) => port && String(port) !== defaultPort(schema) ? `:${port}` : '';
+
+export const endpointToUrl = ({ scheme, host, path, port }) => (
+    `${scheme}://${host}${schemaToPort(scheme, port)}${path || ''}`
+);
 
 export const sourceIsOpenShift = (source, sourceTypes) => {
     const type = sourceTypes.find((type) => type.id === source.source_type_id);

--- a/src/test/components/SourcesSimpleView/formatters.spec.js
+++ b/src/test/components/SourcesSimpleView/formatters.spec.js
@@ -6,7 +6,10 @@ import {
     sourceTypeFormatter,
     applicationFormatter,
     formatURL,
-    sourceIsOpenShift
+    sourceIsOpenShift,
+    defaultPort,
+    schemaToPort,
+    endpointToUrl
 } from '../../../components/SourcesSimpleView/formatters';
 import { sourceTypesData, OPENSHIFT_ID, AMAZON_ID, OPENSHIFT_INDEX } from '../../sourceTypesData';
 import { sourcesDataGraphQl, SOURCE_CATALOGAPP_INDEX, SOURCE_ALL_APS_INDEX, SOURCE_NO_APS_INDEX, SOURCE_ENDPOINT_URL_INDEX } from '../../sourcesData';
@@ -111,7 +114,61 @@ describe('formatters', () => {
 
     describe('formatURL', () => {
         it('returns URL', () => {
-            expect(formatURL(sourcesDataGraphQl[SOURCE_ENDPOINT_URL_INDEX])).toEqual('https://myopenshiftcluster.mycompany.com:null/');
+            expect(formatURL(sourcesDataGraphQl[SOURCE_ENDPOINT_URL_INDEX])).toEqual('https://myopenshiftcluster.mycompany.com/');
+        });
+    });
+
+    describe('defaultPort', () => {
+        it('returns default port 80 for HTTP', () => {
+            expect(defaultPort('http')).toEqual('80');
+        });
+
+        it('returns default port 443 for HTTPs', () => {
+            expect(defaultPort('https')).toEqual('443');
+        });
+
+        it('returns undefined port 443 for uknown scheme', () => {
+            expect(defaultPort('mttp')).toEqual(undefined);
+        });
+    });
+
+    describe('schemaToPort', () => {
+        it('correctly parses port', () => {
+            expect(schemaToPort('https', 444)).toEqual(':444');
+        });
+
+        it('correctly parses string port', () => {
+            expect(schemaToPort('https', '444')).toEqual(':444');
+        });
+
+        it('correctly parses default port', () => {
+            expect(schemaToPort('https', 443)).toEqual('');
+        });
+
+        it('correctly parses undefined port', () => {
+            expect(schemaToPort('https', undefined)).toEqual('');
+        });
+    });
+
+    describe('endpointToUrl', () => {
+        let endpoint;
+        const CUSTOM_PORT = 123456789;
+
+        beforeEach(() => {
+            endpoint = {
+                scheme: 'https',
+                port: 443,
+                path: '/',
+                host: 'my.best.page'
+            };
+        });
+
+        it('correctly parses URL with default port', () => {
+            expect(endpointToUrl(endpoint)).toEqual('https://my.best.page/');
+        });
+
+        it('correctly parses URL with custom port', () => {
+            expect(endpointToUrl({ ...endpoint, port: CUSTOM_PORT })).toEqual(`https://my.best.page:${CUSTOM_PORT}/`);
         });
     });
 });


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-697

**Description**

- Hide empty/default ports in the table/edit form
- little refactoring (using `Promise.all` for faster loading times)
- name validator in edit form (used from `frontend-components-sources`)
- hide `Application` in the edit summary

**Before**

List

![image](https://user-images.githubusercontent.com/32869456/65879560-55746d00-e390-11e9-8825-7a43d0d4ec29.png)

Undefined/Default

![image](https://user-images.githubusercontent.com/32869456/65879438-147c5880-e390-11e9-9ff5-63c3abfee961.png)

**After**

List

![image](https://user-images.githubusercontent.com/32869456/65879534-468dba80-e390-11e9-82b8-7938cb949e9e.png)

Undefined/Default

![image](https://user-images.githubusercontent.com/32869456/65879409-04647900-e390-11e9-8e5f-c95cff4ddc39.png)


