### PR TITLE
Show created source first

### DIFF
--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -128,7 +128,7 @@ const SourcesPage = ({
                 applicationTypes={appTypes}
                 isOpen={true}
                 onClose={() => history.push('/')}
-                afterSuccess={() => loadEntities()}
+                afterSuccess={() => loadEntities({ pageNumber: 1, sortBy: 'created_at', sortDirection: 'desc' })}
                 hideSourcesButton={true}
             />}
             { editorEdit && <SourceEditModal />}

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -19,13 +19,14 @@ import {
 } from '../../api/entities';
 import { doLoadSourceTypes } from '../../api/source_types';
 
-export const loadEntities = () => (dispatch) => {
+export const loadEntities = (options) => (dispatch) => {
     dispatch({ type: ACTION_TYPES.LOAD_ENTITIES_PENDING });
 
     return doLoadEntities().then(({ sources }) => {
         dispatch({
             type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED,
-            payload: sources
+            payload: sources,
+            ...options
         });
     }).catch(error => dispatch({
         type: ACTION_TYPES.LOAD_ENTITIES_REJECTED,

--- a/src/redux/reducers/providers.js
+++ b/src/redux/reducers/providers.js
@@ -11,7 +11,7 @@ import {
 
 export const defaultProvidersState = {
     loaded: false,
-    pageSize: 10,
+    pageSize: 50,
     pageNumber: 1, // PF numbers pages from 1. Seriously.
     entities: [],
     numberOfEntities: 0,
@@ -25,8 +25,9 @@ const entitiesPending = (state) => ({
     loaded: false
 });
 
-const entitiesLoaded = (state, { payload: rows }) => ({
+export const entitiesLoaded = (state, { payload: rows, ...rest }) => ({
     ...state,
+    ...rest,
     loaded: true,
     entities: rows,
     numberOfEntities: rows.length

--- a/src/test/redux/reducer.spec.js
+++ b/src/test/redux/reducer.spec.js
@@ -1,0 +1,39 @@
+import { entitiesLoaded, defaultProvidersState } from '../../redux/reducers/providers';
+
+describe('redux > sources reducer', () => {
+    describe('entitiesLoaded', () => {
+        const SOURCES = [{ id: '1', name: 'name1' }, { id: '2', name: 'name2' }];
+        const DATA = { payload: SOURCES };
+
+        const EXPECTED_STATE = {
+            ...defaultProvidersState,
+            entities: SOURCES,
+            numberOfEntities: SOURCES.length,
+            loaded: true
+        };
+
+        it('loads the entities', () => {
+            expect(entitiesLoaded(defaultProvidersState, DATA)).toEqual(
+                expect.objectContaining(EXPECTED_STATE)
+            );
+        });
+
+        it('pass additional props', () => {
+            const ADDITIONAL_OPTIONS = {
+                pageNumber: 1
+            };
+
+            const NEW_DATA = {
+                ...DATA,
+                ...ADDITIONAL_OPTIONS
+            };
+
+            expect(entitiesLoaded(defaultProvidersState, NEW_DATA)).toEqual(
+                expect.objectContaining({
+                    ...EXPECTED_STATE,
+                    ...ADDITIONAL_OPTIONS
+                })
+            );
+        });
+    });
+});


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-715?filter=-1

**Description**

- After creating a source, the source table is set to be sorted by `created_column` and by newest
- also set initial page size to 50

After creation `TestOrdering` source:

![image](https://user-images.githubusercontent.com/32869456/66750396-a43ffd80-ee8c-11e9-9b28-0d9e8d84ddf5.png)


@Hyperkid123 @terezanovotna
