### PR TITLE
Fix vertical align css in action cell

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -35,5 +35,7 @@
 }
 
 .ins-c-sources__row-vertical-centered {
-  vertical-align: middle !important;
+  td {
+    vertical-align: middle !important;
+  }
 }

--- a/src/components/SourcesSimpleView/SourcesSimpleView.js
+++ b/src/components/SourcesSimpleView/SourcesSimpleView.js
@@ -13,10 +13,7 @@ import { prepareEntities } from '../../Utilities/filteringSorting';
 
 const itemToCells = (item, columns, sourceTypes, appTypes) => columns.filter(column => column.title)
 .map(col => ({
-    title: col.formatter ? formatters(col.formatter)(item[col.value], item, { sourceTypes, appTypes }) : item[col.value] || '',
-    props: {
-        className: 'ins-c-sources__row-vertical-centered'
-    }
+    title: col.formatter ? formatters(col.formatter)(item[col.value], item, { sourceTypes, appTypes }) : item[col.value] || ''
 }));
 
 const renderSources = (entities, columns, sourceTypes, appTypes) =>

--- a/src/components/SourcesSimpleView/loaders.js
+++ b/src/components/SourcesSimpleView/loaders.js
@@ -28,8 +28,9 @@ export const PlaceHolderTable = () => (
     </table>
 );
 
-export const RowWrapperLoader = ({ row: { isDeleting, ...row }, ...initialProps }) => (
-    isDeleting ? <tr><td colSpan="5"><RowLoader /></td></tr> : <RowWrapper {...initialProps} row={row}/>
+export const RowWrapperLoader = ({ row: { isDeleting, ...row }, ...initialProps }) => (isDeleting ?
+    <tr><td colSpan="5"><RowLoader /></td></tr> :
+    <RowWrapper {...initialProps} row={row} className='ins-c-sources__row-vertical-centered'/>
 );
 
 RowWrapperLoader.propTypes = {

--- a/src/test/components/SourcesSimpleView/SourcesSimpleView.spec.js
+++ b/src/test/components/SourcesSimpleView/SourcesSimpleView.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import thunk from 'redux-thunk';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
 import configureStore from 'redux-mock-store';
-import { Table, TableHeader, TableBody, RowWrapper, BodyCell } from '@patternfly/react-table';
+import { Table, TableHeader, TableBody, RowWrapper } from '@patternfly/react-table';
 import { MemoryRouter } from 'react-router-dom';
 
 import SourcesSimpleView from '../../../components/SourcesSimpleView/SourcesSimpleView';
@@ -96,7 +96,7 @@ describe('SourcesSimpleView', () => {
     });
 
     it('renders table when loaded', (done) => {
-        const BODY_CELL_CLASSNAME = 'ins-c-sources__row-vertical-centered';
+        const ROW_WRAPPER_CLASSNAME = 'ins-c-sources__row-vertical-centered';
         initialState = {
             providers: {
                 ...initialState.providers,
@@ -115,7 +115,7 @@ describe('SourcesSimpleView', () => {
                 expect(wrapper.find(TableHeader)).toHaveLength(1);
                 expect(wrapper.find(TableBody)).toHaveLength(1);
                 expect(wrapper.find(RowWrapper)).toHaveLength(sourcesDataGraphQl.length);
-                expect(wrapper.find(BodyCell).first().props().className).toEqual(BODY_CELL_CLASSNAME);
+                expect(wrapper.find(RowWrapper).first().props().className).toEqual(ROW_WRAPPER_CLASSNAME);
                 done();
             });
         });


### PR DESCRIPTION
**Description**

Due to some crazy CSS magic (and our sharpy eyes :eyes: ) the bug was introduced in https://github.com/ManageIQ/sources-ui/pull/117

The last cell, which contains the dropdown, cannot get the `className`, so I had to move the className one level up and use `td` to modify CSS.

**Before**

![image](https://user-images.githubusercontent.com/32869456/66818381-87173780-ef3d-11e9-9ac7-5cafa1e9fe92.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/66828698-fb5bd600-ef51-11e9-80f0-446ef32cc3f4.png)


@Hyperkid123

@miq-bot add_label bug