### PR TITLE
Use ApplicationsList in SourceRemoveModal

### DIFF
--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -15,6 +15,8 @@ import FinishedStep from '../steps/FinishedStep';
 
 import { doCreateApplication } from '../../api/entities';
 
+import RedirectNoId from '../RedirectNoId/RedirectNoId';
+
 const initialState = {
     state: 'wizard',
     error: '',
@@ -29,7 +31,7 @@ const AddApplication = (
     const [state, setState] = useReducer(reducer, initialState);
 
     if (!source || !appTypesLoaded || !sourceTypesLoaded) {
-        return null;
+        return <RedirectNoId />;
     }
 
     const appIds = source.applications.filter(({ isDeleting }) => !isDeleting)

--- a/src/components/AddApplication/AddApplicationDescription.js
+++ b/src/components/AddApplication/AddApplicationDescription.js
@@ -8,62 +8,24 @@ import {
     TextVariants,
     Grid,
     GridItem,
-    Text,
-    Button,
-    ButtonVariant
+    Text
 } from '@patternfly/react-core';
+
 import RemoveAppModal from './RemoveAppModal';
+import ApplicationList from '../ApplicationsList/ApplicationList';
 
-const AddApplicationDescription = ({ appTypes, source, sourceTypes }) => {
-    const [removingApp, setApplicationRemove] = useState({});
-
-    const sourceAppsNames = source.applications
-    .map(({ application_type_id }) => appTypes.find(({ id }) => id === application_type_id).display_name);
+const AddApplicationDescription = ({ source, sourceTypes }) => {
+    const [removingApp, setApplicationToRemove] = useState({});
 
     const sourceType = sourceTypes.find((type) => type.id === source.source_type_id);
-    const appNames = source.applications
-    .filter((app) => !app.isDeleting)
-    .map((app) => {
-        const type = appTypes.find((appType) => appType.id === app.application_type_id);
-
-        if (type) {
-            return {
-                display_name: type.display_name,
-                id: app.id,
-                dependent_applications: type.dependent_applications
-            };
-        }
-    })
-    .sort((a, b) => a.display_name.localeCompare(b.display_name))
-    .map(({ display_name, id, dependent_applications }) => (
-        <Grid key={id}>
-            <GridItem md={4}>
-                <Text component={TextVariants.p} style={{ marginBottom: 0 }}>
-                    { display_name }
-                </Text>
-            </GridItem>
-            <GridItem md={8} className="ins-c-sources__remove-app">
-                <Button
-                    variant={ButtonVariant.link}
-                    isInline
-                    onClick={() => setApplicationRemove({ id, display_name, dependent_applications, sourceAppsNames })}
-                >
-                    <FormattedMessage
-                        id="sources.remove"
-                        defaultMessage="Remove"
-                    />
-                </Button>
-            </GridItem>
-        </Grid>
-    ));
+    const apps = source.applications.filter((app) => !app.isDeleting)
 
     return (
         <React.Fragment>
             {removingApp.id && <RemoveAppModal
                 app={removingApp}
-                onCancel={() => setApplicationRemove({})}
+                onCancel={() => setApplicationToRemove({})}
                 sourceId={source.id}
-                appTypes={appTypes}
             />}
             <TextContent>
                 <Grid gutter="md">
@@ -105,7 +67,7 @@ const AddApplicationDescription = ({ appTypes, source, sourceTypes }) => {
                         </Text>
                     </GridItem>
                     <GridItem md={8}>
-                        {appNames.length > 0 ? appNames : <FormattedMessage
+                        {apps.length > 0 ? <ApplicationList setApplicationToRemove={setApplicationToRemove}/> : <FormattedMessage
                             id="sources.noApps"
                             defaultMessage="No applications"
                         />}
@@ -132,7 +94,7 @@ AddApplicationDescription.propTypes = {
     })
 };
 
-const mapStateToProps = ({ providers: { entities, appTypes, sourceTypes } }, { match: { params: { id } } }) =>
-    ({ source: entities.find(source => source.id  === id), appTypes, sourceTypes });
+const mapStateToProps = ({ providers: { entities, sourceTypes } }, { match: { params: { id } } }) =>
+    ({ source: entities.find(source => source.id  === id), sourceTypes });
 
 export default withRouter(connect(mapStateToProps)(AddApplicationDescription));

--- a/src/components/AddApplication/AddApplicationDescription.js
+++ b/src/components/AddApplication/AddApplicationDescription.js
@@ -18,14 +18,13 @@ const AddApplicationDescription = ({ source, sourceTypes }) => {
     const [removingApp, setApplicationToRemove] = useState({});
 
     const sourceType = sourceTypes.find((type) => type.id === source.source_type_id);
-    const apps = source.applications.filter((app) => !app.isDeleting)
+    const apps = source.applications.filter((app) => !app.isDeleting);
 
     return (
         <React.Fragment>
             {removingApp.id && <RemoveAppModal
                 app={removingApp}
                 onCancel={() => setApplicationToRemove({})}
-                sourceId={source.id}
             />}
             <TextContent>
                 <Grid gutter="md">

--- a/src/components/AddApplication/AddApplicationDescription.js
+++ b/src/components/AddApplication/AddApplicationDescription.js
@@ -13,9 +13,14 @@ import {
 
 import RemoveAppModal from './RemoveAppModal';
 import ApplicationList from '../ApplicationsList/ApplicationList';
+import RedirectNoId from '../RedirectNoId/RedirectNoId';
 
 const AddApplicationDescription = ({ source, sourceTypes }) => {
     const [removingApp, setApplicationToRemove] = useState({});
+
+    if (!source) {
+        return <RedirectNoId />;
+    }
 
     const sourceType = sourceTypes.find((type) => type.id === source.source_type_id);
     const apps = source.applications.filter((app) => !app.isDeleting);

--- a/src/components/AddApplication/AddApplicationSummary.js
+++ b/src/components/AddApplication/AddApplicationSummary.js
@@ -11,7 +11,13 @@ import {
     TextListItemVariants
 } from '@patternfly/react-core';
 
+import RedirectNoId from '../RedirectNoId/RedirectNoId';
+
 const Summary = ({ formOptions, sourceTypes, appTypes, source }) => {
+    if (!source) {
+        return <RedirectNoId />;
+    }
+
     const type = sourceTypes.find((sourceType) => sourceType.id === source.source_type_id);
     const applicationId = formOptions.getState().values.application;
     const application = appTypes.find((app) => app.id === applicationId);

--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -14,9 +14,11 @@ import {
     TextVariants
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { withRouter } from 'react-router-dom';
+
 import { removeApplication } from '../../redux/actions/providers';
 
-const RemoveAppModal = ({ app, onCancel, intl, removeApplication, sourceId, appTypes }) => {
+const RemoveAppModal = ({ app, onCancel, intl, removeApplication, source, appTypes }) => {
     const dependentApps = app.dependent_applications.map(appName => {
         const appType = appTypes.find(({ name }) => name === appName);
 
@@ -38,7 +40,7 @@ const RemoveAppModal = ({ app, onCancel, intl, removeApplication, sourceId, appT
             name: app.display_name
         });
         onCancel();
-        return removeApplication(app.id, sourceId, titleSuccess, titleError);
+        return removeApplication(app.id, source.id, titleSuccess, titleError);
     };
 
     return (
@@ -109,7 +111,9 @@ RemoveAppModal.propTypes = {
     intl: PropTypes.shape({
         formatMessage: PropTypes.func.isRequired
     }).isRequired,
-    sourceId: PropTypes.string.isRequired,
+    source: PropTypes.shape({
+        id: PropTypes.string.isRequired
+    }).isRequired,
     appTypes: PropTypes.arrayOf(PropTypes.shape({
         display_name: PropTypes.string.isRequired
     })).isRequired
@@ -117,6 +121,12 @@ RemoveAppModal.propTypes = {
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ removeApplication }, dispatch);
 
-const mapStateToProps = ({ providers: { appTypes } }) => ({ appTypes });
+const mapStateToProps = (
+    { providers: { entities, appTypes } },
+    { match: { params: { id } } }
+) => ({
+    appTypes,
+    source: entities.find(source => source.id  === id)
+});
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(RemoveAppModal));
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(injectIntl(RemoveAppModal)));

--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -17,8 +17,13 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { withRouter } from 'react-router-dom';
 
 import { removeApplication } from '../../redux/actions/providers';
+import RedirectNoId from '../RedirectNoId/RedirectNoId';
 
 const RemoveAppModal = ({ app, onCancel, intl, removeApplication, source, appTypes }) => {
+    if (!source) {
+        return <RedirectNoId/>;
+    }
+
     const dependentApps = app.dependent_applications.map(appName => {
         const appType = appTypes.find(({ name }) => name === appName);
 

--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -117,4 +117,6 @@ RemoveAppModal.propTypes = {
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ removeApplication }, dispatch);
 
-export default connect(null, mapDispatchToProps)(injectIntl(RemoveAppModal));
+const mapStateToProps = ({ providers: { appTypes } }) => ({ appTypes });
+
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(RemoveAppModal));

--- a/src/components/ApplicationsList/ApplicationList.js
+++ b/src/components/ApplicationsList/ApplicationList.js
@@ -13,7 +13,7 @@ import {
     ButtonVariant
 } from '@patternfly/react-core';
 
-const ApplicationList = ({ appTypes, source, setApplicationToRemove }) => {
+const ApplicationList = ({ appTypes, source, setApplicationToRemove, breakpoints, namePrefix }) => {
     const sourceAppsNames = source.applications
     .map(({ application_type_id }) => appTypes.find(({ id }) => id === application_type_id).display_name);
 
@@ -34,12 +34,12 @@ const ApplicationList = ({ appTypes, source, setApplicationToRemove }) => {
     .map(({ display_name, id, dependent_applications }) => (
         <TextContent key={id}>
             <Grid>
-                <GridItem md={4}>
+                <GridItem md={breakpoints.display_name || 4}>
                     <Text component={TextVariants.p} style={{ marginBottom: 0 }}>
-                        { display_name }
+                        { namePrefix }{ display_name }
                     </Text>
                 </GridItem>
-                <GridItem md={8} className="ins-c-sources__remove-app">
+                <GridItem md={breakpoints.remove || 8} className="ins-c-sources__remove-app">
                     <Button
                         variant={ButtonVariant.link}
                         isInline
@@ -66,7 +66,16 @@ ApplicationList.propTypes = {
         source_type_id: PropTypes.string.isRequired,
         application_type_id: PropTypes.number
     }).isRequired,
-    setApplicationToRemove: PropTypes.func.isRequired
+    setApplicationToRemove: PropTypes.func.isRequired,
+    breakpoints: PropTypes.shape({
+        display_name: PropTypes.number,
+        remove: PropTypes.number
+    }),
+    namePrefix: PropTypes.node
+};
+
+ApplicationList.defaultProps = {
+    breakpoints: {}
 };
 
 const mapStateToProps = ({ providers: { entities, appTypes } }, { match: { params: { id } } }) =>

--- a/src/components/ApplicationsList/ApplicationList.js
+++ b/src/components/ApplicationsList/ApplicationList.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { FormattedMessage } from 'react-intl';
+import {
+    TextContent,
+    TextVariants,
+    Grid,
+    GridItem,
+    Text,
+    Button,
+    ButtonVariant
+} from '@patternfly/react-core';
+
+const ApplicationList = ({ appTypes, source, setApplicationToRemove }) => {
+    const sourceAppsNames = source.applications
+    .map(({ application_type_id }) => appTypes.find(({ id }) => id === application_type_id).display_name);
+
+    return source.applications
+    .filter((app) => !app.isDeleting)
+    .map((app) => {
+        const type = appTypes.find((appType) => appType.id === app.application_type_id);
+
+        if (type) {
+            return {
+                display_name: type.display_name,
+                id: app.id,
+                dependent_applications: type.dependent_applications
+            };
+        }
+    })
+    .sort((a, b) => a.display_name.localeCompare(b.display_name))
+    .map(({ display_name, id, dependent_applications }) => (
+        <TextContent key={id}>
+            <Grid>
+                <GridItem md={4}>
+                    <Text component={TextVariants.p} style={{ marginBottom: 0 }}>
+                        { display_name }
+                    </Text>
+                </GridItem>
+                <GridItem md={8} className="ins-c-sources__remove-app">
+                    <Button
+                        variant={ButtonVariant.link}
+                        isInline
+                        onClick={() => setApplicationToRemove({ id, display_name, dependent_applications, sourceAppsNames })}
+                    >
+                        <FormattedMessage
+                            id="sources.remove"
+                            defaultMessage="Remove"
+                        />
+                    </Button>
+                </GridItem>
+            </Grid>
+        </TextContent>
+    ));
+};
+
+ApplicationList.propTypes = {
+    appTypes: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        display_name: PropTypes.string.isRequired
+    })).isRequired,
+    source: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        source_type_id: PropTypes.string.isRequired,
+        application_type_id: PropTypes.number
+    }).isRequired,
+    setApplicationToRemove: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ providers: { entities, appTypes } }, { match: { params: { id } } }) =>
+    ({ source: entities.find(source => source.id  === id), appTypes });
+
+export default withRouter(connect(mapStateToProps)(ApplicationList));

--- a/src/components/ApplicationsList/ApplicationList.js
+++ b/src/components/ApplicationsList/ApplicationList.js
@@ -13,9 +13,18 @@ import {
     ButtonVariant
 } from '@patternfly/react-core';
 
+import RedirectNoId from '../RedirectNoId/RedirectNoId';
+
 const ApplicationList = ({ appTypes, source, setApplicationToRemove, breakpoints, namePrefix }) => {
+    if (!source) {
+        return <RedirectNoId/>;
+    }
+
     const sourceAppsNames = source.applications
-    .map(({ application_type_id }) => appTypes.find(({ id }) => id === application_type_id).display_name);
+    .map(({ application_type_id }) => {
+        const appType = appTypes.find(({ id }) => id === application_type_id);
+        return appType ? appType.display_name : undefined;
+    });
 
     return source.applications
     .filter((app) => !app.isDeleting)

--- a/src/components/RedirectNoId/RedirectNoId.js
+++ b/src/components/RedirectNoId/RedirectNoId.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { withRouter, Redirect } from 'react-router-dom';
+import { injectIntl } from 'react-intl';
+
+import { addMessage } from '../../redux/actions/providers';
+
+const RedirectNoId = ({ loaded, intl, sourceId, addMessage }) => {
+    if (loaded) {
+        addMessage(
+            intl.formatMessage({
+                id: 'sources.sourceNotFoundTitle',
+                defaultMessage: 'Requested source was not found'
+            }),
+            'danger',
+            intl.formatMessage({
+                id: 'sources.sourceNotFoundTitleDescription',
+                defaultMessage: 'Source with { id } was not found. Try it again later.'
+            }, { id: sourceId })
+        );
+
+        return <Redirect to="/" />;
+    }
+
+    return null;
+};
+
+RedirectNoId.propTypes = {
+    intl: PropTypes.shape({
+        formatMessage: PropTypes.func.isRequired
+    }).isRequired,
+    sourceId: PropTypes.string.isRequired,
+    loaded: PropTypes.bool,
+    addMessage: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ providers: { loaded } }, { match: { params: { id } } }) =>
+    ({ loaded, sourceId: id });
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({ addMessage }, dispatch);
+
+export default injectIntl(withRouter(connect(mapStateToProps, mapDispatchToProps)(RedirectNoId)));

--- a/src/components/SourceRemoveModal.js
+++ b/src/components/SourceRemoveModal.js
@@ -22,6 +22,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 
 import ApplicationList from './ApplicationsList/ApplicationList';
 import RemoveAppModal from './AddApplication/RemoveAppModal';
+import RedirectNoId from './RedirectNoId/RedirectNoId';
 
 const SourceRemoveModal = ({
     history: { push },
@@ -29,6 +30,10 @@ const SourceRemoveModal = ({
     source,
     intl
 }) => {
+    if (!source) {
+        return <RedirectNoId/>;
+    }
+
     const onSubmit = () => {
         push('/');
         return removeSource(source.id, intl.formatMessage({
@@ -41,10 +46,6 @@ const SourceRemoveModal = ({
 
     const [acknowledge, setAcknowledge] = useState(false);
     const [removingApp, setApplicationToRemove] = useState({});
-
-    if (!source) {
-        return null;
-    }
 
     const sourceHasActiveApp = source.applications.some((app) => !app.isDeleting);
 

--- a/src/components/SourceRemoveModal.js
+++ b/src/components/SourceRemoveModal.js
@@ -20,12 +20,14 @@ import { removeSource } from '../redux/actions/providers';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
+import ApplicationList from './ApplicationsList/ApplicationList';
+import RemoveAppModal from './AddApplication/RemoveAppModal';
+
 const SourceRemoveModal = ({
     history: { push },
     removeSource,
     source,
-    intl,
-    appTypes
+    intl
 }) => {
     const onSubmit = () => {
         push('/');
@@ -38,22 +40,13 @@ const SourceRemoveModal = ({
     const onCancel = () => push('/');
 
     const [acknowledge, setAcknowledge] = useState(false);
+    const [removingApp, setApplicationToRemove] = useState({});
 
     if (!source) {
         return null;
     }
 
-    const appNames = source.applications.map((app) => {
-        const type = appTypes.find((appType) => appType.id === app.application_type_id);
-
-        if (type) {
-            return type.display_name;
-        }
-    }).map((name) => (
-        <Text key={name} component={TextVariants.p} style={{ marginBottom: 0 }}>
-            - {name}
-        </Text>
-    ));
+    const sourceHasActiveApp = source.applications.some((app) => !app.isDeleting);
 
     const actions = source.applications.length > 0 ? [
         <Button id="deleteCancel" key="cancel" variant="link" type="button" onClick={ onCancel }>
@@ -100,7 +93,18 @@ const SourceRemoveModal = ({
                     />
                 </Text>
             </Button>
-            { appNames }
+            {
+                sourceHasActiveApp ? <ApplicationList
+                    breakpoints={{ display_name: 8, remove: 4 }}
+                    setApplicationToRemove={setApplicationToRemove}
+                    namePrefix='- '
+                /> : <Text component={ TextVariants.p }>
+                    <FormattedMessage
+                        id="sources.connectedApps"
+                        defaultMessage="Connected applications are being removed."
+                    />
+                </Text>
+            }
         </React.Fragment>
     ) : (
         <React.Fragment>
@@ -166,6 +170,10 @@ const SourceRemoveModal = ({
             actions={ actions }
             isFooterLeftAligned
         >
+            {removingApp.id && <RemoveAppModal
+                app={removingApp}
+                onCancel={() => setApplicationToRemove({})}
+            />}
             <Split gutter="md">
                 <SplitItem><ExclamationTriangleIcon size="xl" className="ins-m-alert ins-c-source__delete-icon" /></SplitItem>
                 <SplitItem isFilled>
@@ -196,8 +204,8 @@ SourceRemoveModal.propTypes = {
     intl: PropTypes.object
 };
 
-const mapStateToProps = ({ providers: { entities, appTypes } }, { match: { params: { id } } }) =>
-    ({ source: entities.find(source => source.id  === id), appTypes });
+const mapStateToProps = ({ providers: { entities } }, { match: { params: { id } } }) =>
+    ({ source: entities.find(source => source.id  === id) });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ removeSource }, dispatch);
 

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -117,7 +117,8 @@ export const addMessage = (title, variant, description) => (dispatch) => dispatc
     payload: {
         title,
         variant,
-        description
+        description,
+        dismissable: true
     }
 });
 

--- a/src/test/components/SourceRemoveModal.spec.js
+++ b/src/test/components/SourceRemoveModal.spec.js
@@ -15,6 +15,7 @@ import { sourcesDataGraphQl } from '../sourcesData';
 import { applicationTypesData } from '../applicationTypesData';
 import RemoveAppModal from '../../components/AddApplication/RemoveAppModal';
 import ApplicationList from '../../components/ApplicationsList/ApplicationList';
+import RedirectNoId from '../../components/RedirectNoId/RedirectNoId';
 
 describe('SourceRemoveModal', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -41,7 +42,7 @@ describe('SourceRemoveModal', () => {
             expect(wrapper.find('button[id="deleteSubmit"]').props().disabled).toEqual(true); // delete is disabled
         });
 
-        it('renders null when no source', () => {
+        it('renders redirect app when no source', () => {
             store = mockStore({
                 providers: { entities: [], appTypes: applicationTypesData.data }
             });
@@ -52,7 +53,7 @@ describe('SourceRemoveModal', () => {
                 ['/remove/14'])
             );
 
-            expect(wrapper.html()).toEqual('');
+            expect(wrapper.find(RedirectNoId)).toHaveLength(1);
         });
 
         it('enables submit button', () => {

--- a/src/test/components/SourceRemoveModal.spec.js
+++ b/src/test/components/SourceRemoveModal.spec.js
@@ -13,6 +13,8 @@ import SourceRemoveModal from '../../components/SourceRemoveModal';
 import { componentWrapperIntl } from '../../Utilities/testsHelpers';
 import { sourcesDataGraphQl } from '../sourcesData';
 import { applicationTypesData } from '../applicationTypesData';
+import RemoveAppModal from '../../components/AddApplication/RemoveAppModal';
+import ApplicationList from '../../components/ApplicationsList/ApplicationList';
 
 describe('SourceRemoveModal', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -37,6 +39,20 @@ describe('SourceRemoveModal', () => {
             expect(wrapper.find('input')).toHaveLength(1); // checkbox
             expect(wrapper.find(Button)).toHaveLength(3); // cancel modal, cancel delete, delete
             expect(wrapper.find('button[id="deleteSubmit"]').props().disabled).toEqual(true); // delete is disabled
+        });
+
+        it('renders null when no source', () => {
+            store = mockStore({
+                providers: { entities: [], appTypes: applicationTypesData.data }
+            });
+
+            const wrapper = mount(componentWrapperIntl(
+                <Route path="/remove/:id" render={ (...args) => <SourceRemoveModal { ...args } /> } />,
+                store,
+                ['/remove/14'])
+            );
+
+            expect(wrapper.html()).toEqual('');
         });
 
         it('enables submit button', () => {
@@ -77,6 +93,9 @@ describe('SourceRemoveModal', () => {
     });
 
     describe('source with applications', () => {
+        const CONNECTED_APPS_BUTTON = 1;
+        const APP_REMOVE_BUTTON = 2;
+
         it('renders correctly', () => {
             const wrapper = mount(componentWrapperIntl(
                 <Route path="/remove/:id" render={ (...args) => <SourceRemoveModal { ...args } /> } />,
@@ -88,8 +107,9 @@ describe('SourceRemoveModal', () => {
             const application = applicationTypesData.data.find((app) => app.id === source.applications[0].application_type_id);
 
             expect(wrapper.find('input')).toHaveLength(0); // checkbox
-            expect(wrapper.find(Button)).toHaveLength(3); // cancel modal, cancel delete, connected apps
+            expect(wrapper.find(Button)).toHaveLength(4); // cancel modal, cancel delete, connected apps, remove the app
             expect(wrapper.find(Text).at(2).text().includes(application.display_name)).toEqual(true); // application in the list
+            expect(wrapper.find(ApplicationList)).toHaveLength(1);
         });
 
         it('clicks on connected apps', () => {
@@ -99,9 +119,51 @@ describe('SourceRemoveModal', () => {
                 ['/remove/406'])
             );
 
-            wrapper.find(Button).at(1).simulate('click'); // Click on redirect
+            wrapper.find(Button).at(CONNECTED_APPS_BUTTON).simulate('click'); // Click on redirect
 
             expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual('/manage_apps/406');
+        });
+
+        it('click on remove app and close it', () => {
+            const REMOVE_APP_CLOSE_BUTTON = 1;
+            const wrapper = mount(componentWrapperIntl(
+                <Route path="/remove/:id" render={ (...args) => <SourceRemoveModal { ...args } /> } />,
+                store,
+                ['/remove/406'])
+            );
+
+            expect(wrapper.find(RemoveAppModal)).toHaveLength(0);
+            wrapper.find(Button).at(APP_REMOVE_BUTTON).simulate('click'); // Click on redirect
+            wrapper.update();
+
+            expect(wrapper.find(RemoveAppModal)).toHaveLength(1);
+
+            wrapper.find(Button).at(REMOVE_APP_CLOSE_BUTTON).simulate('click'); // Click on redirect
+            wrapper.update();
+            expect(wrapper.find(RemoveAppModal)).toHaveLength(0);
+        });
+
+        it('renders correctly when app is being deleted', () => {
+            const APPS_BEING_REMOVED_MSG = 'Connected applications are being removed.';
+            store = mockStore({
+                providers: { entities: [{
+                    ...sourcesDataGraphQl.find((s) => s.id === '406'),
+                    applications: [{
+                        ...sourcesDataGraphQl.find((s) => s.id === '406').applications,
+                        isDeleting: true
+                    }]
+                }
+                ], appTypes: applicationTypesData.data }
+            });
+
+            const wrapper = mount(componentWrapperIntl(
+                <Route path="/remove/:id" render={ (...args) => <SourceRemoveModal { ...args } /> } />,
+                store,
+                ['/remove/406'])
+            );
+
+            expect(wrapper.find(ApplicationList)).toHaveLength(0);
+            expect(wrapper.find(Text).at(2).html().includes(APPS_BEING_REMOVED_MSG)).toEqual(true);
         });
     });
 });

--- a/src/test/components/addApplication/AddApplication.spec.js
+++ b/src/test/components/addApplication/AddApplication.spec.js
@@ -22,6 +22,7 @@ import FinishedStep from '../../../components/steps/FinishedStep';
 import ErroredStep from '../../../components/steps/ErroredStep';
 import LoadingStep from '../../../components/steps/LoadingStep';
 import { paths } from '../../../Routes';
+import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
 describe('AddApplication', () => {
     let store;
@@ -92,6 +93,27 @@ describe('AddApplication', () => {
         ));
 
         expect(wrapper).toEqual({});
+    });
+
+    it('render RedirectNoId when no source', () => {
+        store = mockStore({
+            providers: {
+                entities: [],
+                appTypes: applicationTypesData.data,
+                sourceTypes: sourceTypesData.data,
+                appTypesLoaded: true,
+                sourceTypesLoaded: true
+            }
+        });
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+            store,
+            initialEntry
+        ));
+
+        expect(wrapper).toEqual({});
+        expect(wrapper.find(RedirectNoId)).toHaveLength(1);
     });
 
     it('renders review', () => {

--- a/src/test/components/addApplication/AddApplicationDescription.spec.js
+++ b/src/test/components/addApplication/AddApplicationDescription.spec.js
@@ -13,6 +13,7 @@ import { sourceTypesData } from '../../sourceTypesData';
 import { sourcesDataGraphQl } from '../../sourcesData';
 import { applicationTypesData } from '../../applicationTypesData';
 import RemoveAppModal from '../../../components/AddApplication/RemoveAppModal';
+import ApplicationList from '../../../components/ApplicationsList/ApplicationList';
 
 describe('AddApplicationDescription', () => {
     let store;
@@ -44,6 +45,7 @@ describe('AddApplicationDescription', () => {
 
         expect(wrapper.find(Text).at(3).text()).toEqual(source.name);
         expect(wrapper.find(Text).at(4).text()).toEqual(sourceType.product_name);
+        expect(wrapper.find(ApplicationList).length).toEqual(0);
         expect(wrapper.find(FormattedMessage).last().text()).toEqual('No applications');
         expect(wrapper.find(Button).length).toEqual(0);
     });
@@ -57,11 +59,10 @@ describe('AddApplicationDescription', () => {
 
         const source = sourcesDataGraphQl.find((x) => x.id === '406');
         const sourceType = sourceTypesData.data.find((x) => x.id === source.source_type_id);
-        const applicationType = applicationTypesData.data.find((x) => x.id === source.applications[0].application_type_id);
 
         expect(wrapper.find(Text).at(3).text()).toEqual(source.name);
         expect(wrapper.find(Text).at(4).text()).toEqual(sourceType.product_name);
-        expect(wrapper.find(Text).at(5).text()).toEqual(applicationType.display_name);
+        expect(wrapper.find(ApplicationList).length).toEqual(1);
         expect(wrapper.find(Button).length).toEqual(1);
     });
 
@@ -74,15 +75,10 @@ describe('AddApplicationDescription', () => {
 
         const source = sourcesDataGraphQl.find((x) => x.id === '408');
         const sourceType = sourceTypesData.data.find((x) => x.id === source.source_type_id);
-        const applicationType = applicationTypesData.data.find((x) => x.id === source.applications[0].application_type_id);
-        const applicationType1 = applicationTypesData.data.find((x) => x.id === source.applications[1].application_type_id);
-        const applicationType2 = applicationTypesData.data.find((x) => x.id === source.applications[2].application_type_id);
 
         expect(wrapper.find(Text).at(3).text()).toEqual(source.name);
         expect(wrapper.find(Text).at(4).text()).toEqual(sourceType.product_name);
-        expect(wrapper.find(Text).at(5).text()).toEqual(applicationType.display_name);
-        expect(wrapper.find(Text).at(6).text()).toEqual(applicationType1.display_name);
-        expect(wrapper.find(Text).at(7).text()).toEqual(applicationType2.display_name);
+        expect(wrapper.find(ApplicationList).length).toEqual(1);
         expect(wrapper.find(Button).length).toEqual(3);
     });
 
@@ -101,5 +97,42 @@ describe('AddApplicationDescription', () => {
         wrapper.update();
         expect(wrapper.find(RemoveAppModal).length).toEqual(1);
         expect(wrapper.find(Title).first().text().includes(applicationType.display_name)).toEqual(true);
+    });
+
+    it('show remove app modal and close it', () => {
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/add_application/:id" render={ (...args) => <AddApplicationDescription { ...args }/> } />,
+            store,
+            ['/add_application/406']
+        ));
+
+        expect(wrapper.find(RemoveAppModal).length).toEqual(0);
+
+        wrapper.find(Button).first().simulate('click');
+        wrapper.update();
+        expect(wrapper.find(RemoveAppModal).length).toEqual(1);
+
+        wrapper.find(Button).at(0).simulate('click');
+        wrapper.update();
+        expect(wrapper.find(RemoveAppModal).length).toEqual(0);
+    });
+
+    it('renders correctly when SourceType does not exist', () => {
+        const NOT_FOUND_MSG = 'Type not found';
+        store = mockStore({
+            providers: {
+                entities: sourcesDataGraphQl,
+                appTypes: applicationTypesData.data,
+                sourceTypes: []
+            }
+        });
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/add_application/:id" render={ (...args) => <AddApplicationDescription { ...args }/> } />,
+            store,
+            initialEntry
+        ));
+
+        expect(wrapper.find(Text).at(4).text()).toEqual(NOT_FOUND_MSG);
     });
 });

--- a/src/test/components/addApplication/AddApplicationDescription.spec.js
+++ b/src/test/components/addApplication/AddApplicationDescription.spec.js
@@ -14,6 +14,7 @@ import { sourcesDataGraphQl } from '../../sourcesData';
 import { applicationTypesData } from '../../applicationTypesData';
 import RemoveAppModal from '../../../components/AddApplication/RemoveAppModal';
 import ApplicationList from '../../../components/ApplicationsList/ApplicationList';
+import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
 describe('AddApplicationDescription', () => {
     let store;
@@ -48,6 +49,24 @@ describe('AddApplicationDescription', () => {
         expect(wrapper.find(ApplicationList).length).toEqual(0);
         expect(wrapper.find(FormattedMessage).last().text()).toEqual('No applications');
         expect(wrapper.find(Button).length).toEqual(0);
+    });
+
+    it('renders RedirectNoId', () => {
+        store = mockStore({
+            providers: {
+                entities: [],
+                appTypes: applicationTypesData.data,
+                sourceTypes: sourceTypesData.data
+            }
+        });
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/add_application/:id" render={ (...args) => <AddApplicationDescription { ...args }/> } />,
+            store,
+            initialEntry
+        ));
+
+        expect(wrapper.find(RedirectNoId)).toHaveLength(1);
     });
 
     it('renders correctly with application', () => {

--- a/src/test/components/addApplication/AddApplicationSummary.spec.js
+++ b/src/test/components/addApplication/AddApplicationSummary.spec.js
@@ -11,6 +11,7 @@ import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 import { sourceTypesData } from '../../sourceTypesData';
 import { sourcesDataGraphQl } from '../../sourcesData';
 import { applicationTypesData } from '../../applicationTypesData';
+import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
 describe('AddApplicationSummary', () => {
     let initialProps;
@@ -50,5 +51,23 @@ describe('AddApplicationSummary', () => {
         expect(wrapper.find(TextListItem).at(1).text()).toEqual(source.name);
         expect(wrapper.find(TextListItem).at(3).text()).toEqual(sourceType.product_name);
         expect(wrapper.find(TextListItem).at(5).text()).toEqual(applicationType.display_name);
+    });
+
+    it('renders RedirectNoId with no source', () => {
+        store = mockStore({
+            providers: {
+                entities: [],
+                appTypes: applicationTypesData.data,
+                sourceTypes: sourceTypesData.data
+            }
+        });
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/add_application/:id" render={ (...args) => <AddApplicationSummary { ...args } {...initialProps}/> } />,
+            store,
+            initialEntry
+        ));
+
+        expect(wrapper.find(RedirectNoId)).toHaveLength(1);
     });
 });

--- a/src/test/components/addApplication/RemoveAppModal.spec.js
+++ b/src/test/components/addApplication/RemoveAppModal.spec.js
@@ -33,7 +33,11 @@ describe('RemoveAppModal', () => {
 
     beforeEach(() => {
         mockStore = configureStore();
-        store = mockStore();
+        store = mockStore({
+            providers: {
+                appTypes: []
+            }
+        });
         spyOnCancel = jest.fn();
         initialProps = {
             app: {
@@ -42,8 +46,7 @@ describe('RemoveAppModal', () => {
                 dependent_applications: []
             },
             onCancel: spyOnCancel,
-            sourceId: SOURCE_ID,
-            appTypes: []
+            sourceId: SOURCE_ID
         };
     });
 
@@ -75,10 +78,16 @@ describe('RemoveAppModal', () => {
             sourceAppsNames: ATTACHED_APPS
         };
 
+        store = mockStore({
+            providers: {
+                appTypes: APP_TYPES
+            }
+        });
+
         const wrapper = mount(
             <IntlProvider locale="en">
                 <Provider store={ store }>
-                    <RemoveAppModal {...initialProps} app={app} appTypes={APP_TYPES}/>
+                    <RemoveAppModal {...initialProps} app={app}/>
                 </Provider>
             </IntlProvider>
         );
@@ -96,10 +105,16 @@ describe('RemoveAppModal', () => {
             sourceAppsNames: ATTACHED_APPS
         };
 
+        store = mockStore({
+            providers: {
+                appTypes: APP_TYPES
+            }
+        });
+
         const wrapper = mount(
             <IntlProvider locale="en">
                 <Provider store={ store }>
-                    <RemoveAppModal {...initialProps} app={app} appTypes={APP_TYPES}/>
+                    <RemoveAppModal {...initialProps} app={app}/>
                 </Provider>
             </IntlProvider>
         );

--- a/src/test/components/addApplication/RemoveAppModal.spec.js
+++ b/src/test/components/addApplication/RemoveAppModal.spec.js
@@ -2,18 +2,22 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Modal, Button, Text } from '@patternfly/react-core';
 import configureStore from 'redux-mock-store';
-import { IntlProvider, FormattedMessage } from 'react-intl';
-import { Provider } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
 import * as redux from 'redux';
+import { Route } from 'react-router-dom';
 
 import RemoveAppModal from '../../../components/AddApplication/RemoveAppModal';
 import * as actions from '../../../redux/actions/providers';
+import { paths } from '../../../Routes';
+import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 
 describe('RemoveAppModal', () => {
     let store;
     let mockStore;
     let initialProps;
     let spyOnCancel;
+    let initialEntry;
+    let initialStore;
 
     const APP_ID = '187894151315';
     const SOURCE_ID = '15';
@@ -31,13 +35,17 @@ describe('RemoveAppModal', () => {
         { name: APP2, display_name: APP2_DISPLAY_NAME }
     ];
 
+    const PATH = '/manage_apps/';
+
     beforeEach(() => {
-        mockStore = configureStore();
-        store = mockStore({
+        initialStore = {
             providers: {
-                appTypes: []
+                appTypes: [],
+                entities: [{ id: SOURCE_ID }]
             }
-        });
+        };
+        mockStore = configureStore();
+        store = mockStore(initialStore);
         spyOnCancel = jest.fn();
         initialProps = {
             app: {
@@ -45,9 +53,9 @@ describe('RemoveAppModal', () => {
                 display_name: 'Catalog',
                 dependent_applications: []
             },
-            onCancel: spyOnCancel,
-            sourceId: SOURCE_ID
+            onCancel: spyOnCancel
         };
+        initialEntry = [`${PATH}${SOURCE_ID}`];
     });
 
     afterEach(() => {
@@ -55,13 +63,11 @@ describe('RemoveAppModal', () => {
     });
 
     it('renders correctly', () => {
-        const wrapper = mount(
-            <IntlProvider locale="en">
-                <Provider store={ store }>
-                    <RemoveAppModal {...initialProps} />
-                </Provider>
-            </IntlProvider>
-        );
+        const wrapper = mount(componentWrapperIntl(
+            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} /> } />,
+            store,
+            initialEntry
+        ));
 
         expect(wrapper.find(Modal).length).toEqual(1);
         expect(wrapper.find(Button).length).toEqual(3); // modal cancel, remove, cancel
@@ -80,17 +86,16 @@ describe('RemoveAppModal', () => {
 
         store = mockStore({
             providers: {
+                ...initialStore.providers,
                 appTypes: APP_TYPES
             }
         });
 
-        const wrapper = mount(
-            <IntlProvider locale="en">
-                <Provider store={ store }>
-                    <RemoveAppModal {...initialProps} app={app}/>
-                </Provider>
-            </IntlProvider>
-        );
+        const wrapper = mount(componentWrapperIntl(
+            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} app={app}/> } />,
+            store,
+            initialEntry
+        ));
 
         expect(wrapper.find(Text)).toHaveLength(2);
         expect(wrapper.find(Text).last().html().includes(APP1_DISPLAY_NAME)).toEqual(true);
@@ -107,17 +112,16 @@ describe('RemoveAppModal', () => {
 
         store = mockStore({
             providers: {
+                ...initialStore.providers,
                 appTypes: APP_TYPES
             }
         });
 
-        const wrapper = mount(
-            <IntlProvider locale="en">
-                <Provider store={ store }>
-                    <RemoveAppModal {...initialProps} app={app}/>
-                </Provider>
-            </IntlProvider>
-        );
+        const wrapper = mount(componentWrapperIntl(
+            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} app={app}/> } />,
+            store,
+            initialEntry
+        ));
 
         expect(wrapper.find(Text)).toHaveLength(1);
         expect(wrapper.find(Text).last().html().includes(APP1_DISPLAY_NAME)).toEqual(false);
@@ -125,13 +129,11 @@ describe('RemoveAppModal', () => {
     });
 
     it('calls cancel', () => {
-        const wrapper = mount(
-            <IntlProvider locale="en">
-                <Provider store={ store }>
-                    <RemoveAppModal {...initialProps} />
-                </Provider>
-            </IntlProvider>
-        );
+        const wrapper = mount(componentWrapperIntl(
+            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps}/> } />,
+            store,
+            initialEntry
+        ));
 
         wrapper.find(Button).last().simulate('click');
         expect(spyOnCancel).toHaveBeenCalled();
@@ -141,13 +143,11 @@ describe('RemoveAppModal', () => {
         redux.bindActionCreators = jest.fn(x => x);
         actions.removeApplication = jest.fn(() => new Promise((resolve) => resolve('OK')));
 
-        const wrapper = mount(
-            <IntlProvider locale="en">
-                <Provider store={ store }>
-                    <RemoveAppModal {...initialProps} />
-                </Provider>
-            </IntlProvider>
-        );
+        const wrapper = mount(componentWrapperIntl(
+            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps}/> } />,
+            store,
+            initialEntry
+        ));
 
         wrapper.find(Button).at(1).simulate('click');
 

--- a/src/test/components/addApplication/RemoveAppModal.spec.js
+++ b/src/test/components/addApplication/RemoveAppModal.spec.js
@@ -10,6 +10,7 @@ import RemoveAppModal from '../../../components/AddApplication/RemoveAppModal';
 import * as actions from '../../../redux/actions/providers';
 import { paths } from '../../../Routes';
 import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
+import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
 describe('RemoveAppModal', () => {
     let store;
@@ -74,6 +75,25 @@ describe('RemoveAppModal', () => {
         expect(wrapper.find(FormattedMessage).length).toEqual(3);
         expect(wrapper.find(Button).at(1).text()).toEqual('Remove');
         expect(wrapper.find(Button).last().text()).toEqual('Cancel');
+    });
+
+    it('renders correctly RedirectNoId with no source', () => {
+        initialStore = {
+            providers: {
+                appTypes: [],
+                entities: []
+            }
+        };
+
+        store = mockStore(initialStore);
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} /> } />,
+            store,
+            initialEntry
+        ));
+
+        expect(wrapper.find(RedirectNoId)).toHaveLength(1);
     });
 
     it('renders correctly with attached dependent applications', () => {

--- a/src/test/components/applicationList/ApplicationList.spec.js
+++ b/src/test/components/applicationList/ApplicationList.spec.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Button } from '@patternfly/react-core';
+import configureStore from 'redux-mock-store';
+import { Route } from 'react-router-dom';
+import { Text } from '@patternfly/react-core';
+
+import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
+import ApplicationList from '../../../components/ApplicationsList/ApplicationList';
+import { sourceTypesData } from '../../sourceTypesData';
+import { sourcesDataGraphQl, SOURCE_ALL_APS_ID, SOURCE_ONE_APS_ID } from '../../sourcesData';
+import { applicationTypesData } from '../../applicationTypesData';
+
+describe('ApplicationList', () => {
+    let store;
+    let mockStore;
+    let initialProps;
+    let spySetApp;
+    let initialEntry;
+    let initialStore;
+
+    const PATH = '/manage_apps/';
+
+    beforeEach(() => {
+        initialStore = {
+            providers: {
+                entities: sourcesDataGraphQl,
+                appTypes: applicationTypesData.data,
+                sourceTypes: sourceTypesData.data
+            }
+        };
+        mockStore = configureStore();
+        store = mockStore(initialStore);
+        spySetApp = jest.fn();
+
+        initialProps = {
+            setApplicationToRemove: spySetApp
+        };
+    });
+
+    afterEach(() => {
+        spySetApp.mockReset();
+    });
+
+    it('renders correctly with application', () => {
+        initialEntry = [`${PATH}${SOURCE_ONE_APS_ID}`];
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/manage_apps/:id" render={ (...args) => <ApplicationList {...initialProps} { ...args }/> } />,
+            store,
+            initialEntry
+        ));
+
+        const source = sourcesDataGraphQl.find((x) => x.id === SOURCE_ONE_APS_ID);
+        const applicationType = applicationTypesData.data.find((x) => x.id === source.applications[0].application_type_id);
+
+        expect(wrapper.find(Text).first().text()).toEqual(applicationType.display_name);
+        expect(wrapper.find(Button)).toHaveLength(1);
+    });
+
+    it('renders correctly with prefix', () => {
+        const PREFIX = '##';
+        initialEntry = [`${PATH}${SOURCE_ONE_APS_ID}`];
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/manage_apps/:id" render={ (...args) => <ApplicationList {...initialProps} { ...args } namePrefix={PREFIX}/> } />,
+            store,
+            initialEntry
+        ));
+
+        const source = sourcesDataGraphQl.find((x) => x.id === SOURCE_ONE_APS_ID);
+        const applicationType = applicationTypesData.data.find((x) => x.id === source.applications[0].application_type_id);
+
+        expect(wrapper.find(Text).first().text()).toEqual(`${PREFIX}${applicationType.display_name}`);
+    });
+
+    it('renders correctly with applications', () => {
+        initialEntry = [`${PATH}${SOURCE_ALL_APS_ID}`];
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/manage_apps/:id" render={ (...args) => <ApplicationList {...initialProps} { ...args }/> } />,
+            store,
+            initialEntry
+        ));
+
+        const source = sourcesDataGraphQl.find((x) => x.id === SOURCE_ALL_APS_ID);
+        const applicationType = applicationTypesData.data.find((x) => x.id === source.applications[0].application_type_id);
+        const applicationType1 = applicationTypesData.data.find((x) => x.id === source.applications[1].application_type_id);
+        const applicationType2 = applicationTypesData.data.find((x) => x.id === source.applications[2].application_type_id);
+
+        expect(wrapper.find(Text).first().text()).toEqual(applicationType.display_name);
+        expect(wrapper.find(Text).at(1).text()).toEqual(applicationType1.display_name);
+        expect(wrapper.find(Text).last().text()).toEqual(applicationType2.display_name);
+        expect(wrapper.find(Button)).toHaveLength(3);
+    });
+});

--- a/src/test/components/applicationList/ApplicationList.spec.js
+++ b/src/test/components/applicationList/ApplicationList.spec.js
@@ -10,6 +10,7 @@ import ApplicationList from '../../../components/ApplicationsList/ApplicationLis
 import { sourceTypesData } from '../../sourceTypesData';
 import { sourcesDataGraphQl, SOURCE_ALL_APS_ID, SOURCE_ONE_APS_ID } from '../../sourcesData';
 import { applicationTypesData } from '../../applicationTypesData';
+import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
 describe('ApplicationList', () => {
     let store;
@@ -56,6 +57,27 @@ describe('ApplicationList', () => {
 
         expect(wrapper.find(Text).first().text()).toEqual(applicationType.display_name);
         expect(wrapper.find(Button)).toHaveLength(1);
+    });
+
+    it('renders RedirectNoId with source', () => {
+        initialEntry = [`${PATH}${SOURCE_ONE_APS_ID}`];
+
+        initialStore = {
+            providers: {
+                entities: [],
+                appTypes: applicationTypesData.data,
+                sourceTypes: sourceTypesData.data
+            }
+        };
+        store = mockStore(initialStore);
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/manage_apps/:id" render={ (...args) => <ApplicationList {...initialProps} { ...args }/> } />,
+            store,
+            initialEntry
+        ));
+
+        expect(wrapper.find(RedirectNoId)).toHaveLength(1);
     });
 
     it('renders correctly with prefix', () => {

--- a/src/test/components/redirectNoId/RedirectNoId.spec.js
+++ b/src/test/components/redirectNoId/RedirectNoId.spec.js
@@ -1,0 +1,55 @@
+import { Route, MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { mount } from 'enzyme';
+
+import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
+import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
+import * as actions from '../../../redux/actions/providers';
+import * as redux from 'redux';
+
+describe('RedirectNoId', () => {
+    let initialStore;
+    let initialEntry;
+    let mockStore;
+
+    const wasRedirectedToRoot = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === '/';
+
+    beforeEach(() => {
+        initialEntry = ['/remove/1'];
+
+        mockStore = configureStore();
+    });
+
+    it('Renders null if not loaded', () => {
+        initialStore = mockStore({
+            providers: { loaded: false }
+        });
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/remove/:id" render={ (...args) => <RedirectNoId { ...args } /> } />,
+            initialStore,
+            initialEntry
+        ));
+
+        expect(wrapper.html()).toEqual('');
+    });
+
+    it('Renders redirect and creates message if loaded', () => {
+        redux.bindActionCreators = jest.fn(x => x);
+        actions.addMessage = jest.fn();
+
+        initialStore = mockStore({
+            providers: { loaded: true }
+        });
+
+        const wrapper = mount(componentWrapperIntl(
+            <Route path="/remove/:id" render={ (...args) => <RedirectNoId { ...args } /> } />,
+            initialStore,
+            initialEntry
+        ));
+
+        expect(actions.addMessage).toHaveBeenCalled();
+
+        expect(wasRedirectedToRoot(wrapper)).toEqual(true);
+    });
+});

--- a/src/test/sourcesData.js
+++ b/src/test/sourcesData.js
@@ -169,3 +169,4 @@ export const SOURCE_NO_APS_ID = '23';
 export const SOURCE_ENDPOINT_URL_INDEX = 3;
 export const SOURCE_CATALOGAPP_INDEX = 3;
 export const SOURCE_ALL_APS_ID = '408';
+export const SOURCE_ONE_APS_ID = '406';


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-722?filter=-1

**Description**

- add `Remove` application buttons to Remove Source modal
- Refactores the Application list to separate component
- Using Redux store instead of passing props in some places
- More tests

**Before**

![image](https://user-images.githubusercontent.com/32869456/67201675-0bb6f980-f407-11e9-91a8-9117e5ae5271.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/67201587-e0cca580-f406-11e9-8819-954f89dfe90e.png)

After click on remove
![image](https://user-images.githubusercontent.com/32869456/67201615-ee822b00-f406-11e9-9a98-59f771966939.png)

@martinpovolny @Hyperkid123 @terezanovotna