### PR TITLE
Fix filtering

### DIFF
--- a/src/Utilities/filteringSorting.js
+++ b/src/Utilities/filteringSorting.js
@@ -1,14 +1,45 @@
-export const sortByCompare = (key, direction) => (a, b) =>
-    (a[key] > b[key]) ? (direction === 'asc' ? 1 : -1) : ((b[key] > a[key]) ? (direction === 'asc' ? -1 : 1) : 0);
+export const sortByCompare = (key, direction, { sourceTypes } = {}) => (a, b) => {
+    if (typeof a[key] === 'string' && typeof b[key] === 'string') {
+        let valueA = a[key].toLowerCase();
+        let valueB = b[key].toLowerCase();
+
+        if (sourceTypes && key === 'source_type_id') {
+            valueA = sourceTypes.find(type => type.id === a[key]);
+            valueA = valueA ? valueA.product_name : '';
+
+            valueB = sourceTypes.find(type => type.id === b[key]);
+            valueB = valueB ? valueB.product_name : '';
+        }
+
+        return direction === 'asc' ? valueA.localeCompare(valueB) : valueB.localeCompare(valueA);
+    }
+
+    if (Array.isArray(a[key]) && Array.isArray(b[key])) {
+        const valueA = a[key].length;
+        const valueB = b[key].length;
+        return (valueA > valueB) ? (direction === 'asc' ? 1 : -1) : ((valueB > valueA) ? (direction === 'asc' ? -1 : 1) : 0);
+    }
+
+    return 0;
+};
 
 export const filterByValue = (entity, column, value) =>
     column && value && value !== '' ? String(entity[column]).toLowerCase().includes(value.toLowerCase()) : true;
 
 export const paginate = (entities, pageNumber, pageSize) => entities.slice((pageNumber - 1) * pageSize, pageNumber * pageSize);
 
-export const prepareEntities = (entities, { sortBy, sortDirection, filterColumn, filterValue, pageNumber, pageSize }) => (
+export const prepareEntities = (entities, {
+    sortBy,
+    sortDirection,
+    filterColumn,
+    filterValue,
+    pageNumber,
+    pageSize,
+    sourceTypes
+}) => (
     paginate(
-        entities.filter(entity => filterByValue(entity, filterColumn, filterValue)).sort(sortByCompare(sortBy, sortDirection)),
+        entities.filter(entity => filterByValue(entity, filterColumn, filterValue))
+        .sort(sortByCompare(sortBy, sortDirection, { sourceTypes })),
         pageNumber,
         pageSize
     )

--- a/src/components/SourcesSimpleView/SourcesSimpleView.js
+++ b/src/components/SourcesSimpleView/SourcesSimpleView.js
@@ -69,7 +69,8 @@ const SourcesSimpleView = ({
                 filterColumn,
                 filterValue,
                 pageNumber,
-                pageSize
+                pageSize,
+                sourceTypes
             }
         ),
         ...additionalOptions

--- a/src/test/utilities/filteringSorting.spec.js
+++ b/src/test/utilities/filteringSorting.spec.js
@@ -2,12 +2,19 @@ import { sortByCompare, filterByValue, paginate, prepareEntities } from '../../U
 
 describe('filteringSorting utilities', () => {
     let testingArray;
+    let testingArrayWithApps;
 
     beforeEach(() => {
         testingArray = [
             { name: 'Bob', id: 8 },
             { name: 'Cecil', id: 1 },
             { name: 'Alois', id: 41 }
+        ];
+
+        testingArrayWithApps = [
+            { apps: ['1', '2'] },
+            { apps: [] },
+            { apps: ['3'] }
         ];
     });
 
@@ -26,6 +33,66 @@ describe('filteringSorting utilities', () => {
                 { name: 'Bob', id: 8 },
                 { name: 'Cecil', id: 1 }
             ]);
+        });
+
+        it('compares array by length ASC', () => {
+            expect(testingArrayWithApps.sort(sortByCompare('apps', 'asc'))).toEqual([
+                { apps: [] },
+                { apps: ['3'] },
+                { apps: ['1', '2'] }
+            ]);
+        });
+
+        it('compares array by length DESC', () => {
+            expect(testingArrayWithApps.sort(sortByCompare('apps', 'desc'))).toEqual([
+                { apps: ['1', '2'] },
+                { apps: ['3'] },
+                { apps: [] }
+            ]);
+        });
+
+        it('do not compare different types', () => {
+            testingArray = [
+                { apps: 'app' },
+                { apps: ['1'] }
+            ];
+
+            expect(testingArray.sort(sortByCompare('apps', 'desc'))).toEqual(testingArray);
+            expect(testingArray.sort(sortByCompare('apps', 'asc'))).toEqual(testingArray);
+        });
+
+        describe('source_type_id', () => {
+            const FIRST_SOURCE_ID = '300';
+            const NEXT_SOURCE_ID = '1';
+            const LAST_SOURCE_ID = '15';
+
+            const SOURCE_TYPES = [
+                { id: NEXT_SOURCE_ID, product_name: 'B' },
+                { id: LAST_SOURCE_ID, product_name: 'C' },
+                { id: FIRST_SOURCE_ID, product_name: 'A' }
+            ];
+
+            const testingArrayTypes = [
+                { source_type_id: NEXT_SOURCE_ID },
+                { source_type_id: LAST_SOURCE_ID },
+                { source_type_id: FIRST_SOURCE_ID }
+            ];
+
+            it('sort ASC', () => {
+                expect(testingArrayTypes.sort(sortByCompare('source_type_id', 'asc', { sourceTypes: SOURCE_TYPES }))).toEqual([
+                    { source_type_id: FIRST_SOURCE_ID },
+                    { source_type_id: NEXT_SOURCE_ID },
+                    { source_type_id: LAST_SOURCE_ID }
+                ]);
+            });
+
+            it('sort DESC', () => {
+                expect(testingArrayTypes.sort(sortByCompare('source_type_id', 'desc', { sourceTypes: SOURCE_TYPES }))).toEqual([
+                    { source_type_id: LAST_SOURCE_ID },
+                    { source_type_id: NEXT_SOURCE_ID },
+                    { source_type_id: FIRST_SOURCE_ID }
+                ]);
+            });
         });
     });
 


### PR DESCRIPTION
**Description**

Fixes filtering until we get proper graphlql sorting:
- arrays are compared by length
- `source_type_id` is compared by `product_name`
- uses `localeCompare` for strings

@Hyperkid123 